### PR TITLE
Link_mode and vdpa is not updated in sriov_map

### DIFF
--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -1040,6 +1040,10 @@ class LinuxBond(_BaseOpts):
         for member in self.members:
             if isinstance(member, SriovPF):
                 utils.update_sriov_pf_map(member.name, member.numvfs, False,
+                                          promisc=member.promisc,
+                                          steering_mode=member.steering_mode,
+                                          link_mode=member.link_mode,
+                                          vdpa=member.vdpa,
                                           lag_candidate=True)
             if isinstance(member, SriovVF):
                 LinuxBond.update_vf_config(member)


### PR DESCRIPTION
When sriov PF map is updated from LinuxBond, it does not update the link_mode and vdpa for the member PF interface

Change-Id: I6564cba495c81760907258058afe411574dc2582 (cherry picked from commit 4deb7a817139fe6982a3f8c78aadba64fc49edc5)