### PR TITLE
Refactor check_configure_sriov to prevent dublicate adding sriov_pfs

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -124,11 +124,15 @@ def parse_opts(argv):
 
 def check_configure_sriov(obj):
     configure_sriov = False
-    for member in obj.members:
-        if isinstance(member, objects.SriovPF):
-            configure_sriov = True
-        elif hasattr(member, "members") and member.members is not None:
-            configure_sriov = check_configure_sriov(member)
+    if isinstance(obj, objects.SriovPF):
+        configure_sriov = True
+    elif hasattr(obj, 'members') and obj.members is not None:
+        for member in obj.members:
+            if isinstance(member, objects.SriovPF):
+                configure_sriov = True
+                break
+            else:
+                configure_sriov = check_configure_sriov(member)
     return configure_sriov
 
 
@@ -282,16 +286,13 @@ def main(argv=sys.argv, main_logger=None):
             obj = objects.object_from_json(iface_json)
         except utils.SriovVfNotFoundException:
             continue
-        if isinstance(obj, objects.SriovPF):
+        if check_configure_sriov(obj):
             configure_sriov = True
             provider.add_object(obj)
-        elif hasattr(obj, 'members') and obj.members is not None:
-            if check_configure_sriov(obj):
-                configure_sriov = True
-                provider.add_object(obj)
-
-                sriovpf_member_of_bond_ovs_port_list.extend(
-                    get_sriovpf_member_of_bond_ovs_port(obj))
+            # Look for the presence of SriovPF as members of LinuxBond and that
+            # LinuxBond is member of OvsBridge
+            sriovpf_member_of_bond_ovs_port_list.extend(
+                get_sriovpf_member_of_bond_ovs_port(obj))
 
     # After reboot, shared_block for pf interface in switchdev mode will be
     # missing in case IPv6 is enabled on the slaves of the bond and that bond
@@ -323,7 +324,8 @@ def main(argv=sys.argv, main_logger=None):
                 restart_openvswitch=restart_ovs)
 
     for iface_json in iface_array:
-        # All objects other than the sriov_pf will be added here.
+        # All sriov_pfs at top level or at any member level will be
+        # ignored and all other objects are parsed will be added here.
         # The VFs are expected to be available now and an exception
         # SriovVfNotFoundException shall be raised if not available.
         try:
@@ -331,7 +333,7 @@ def main(argv=sys.argv, main_logger=None):
         except utils.SriovVfNotFoundException:
             if not opts.noop:
                 raise
-        if not isinstance(obj, objects.SriovPF):
+        if not check_configure_sriov(obj):
             provider.add_object(obj)
 
     if configure_sriov and not opts.noop:


### PR DESCRIPTION
Cuurent implementation of adding objects is dublicating adding objects that have sriov_pf members.
The patch refactors check_configure_sriov to check if the object itself or any of its tree members are sriov_pf so adding that object will happen once

Closes-Bug: #2020100
Change-Id: I3895a5200bc97a294a8b5774c24972f1f58b40bf (cherry picked from commit 7996a2e79e607aed3036bf3a851bde318ff0fef7) (cherry picked from commit 770e41df3c27390a97f581f7f926511362888297)