### PR TITLE
Skip failure on setting inactive interface as bond's primary

### DIFF
--- a/os_net_config/__init__.py
+++ b/os_net_config/__init__.py
@@ -367,7 +367,7 @@ class NetConfig(object):
         self.execute(msg, '/sbin/ip',
                      'link', 'set', 'dev', newname, 'up')
 
-    def ovs_appctl(self, action, *parameters):
+    def ovs_appctl(self, action, *parameters, ignore_err=False):
         """Run 'ovs-appctl' with the specified action
 
          Its possible the command may fail due to timing if, for example,
@@ -383,4 +383,5 @@ class NetConfig(object):
             self.execute(msg, '/bin/ovs-appctl', action, *parameters,
                          delay_on_retry=True, attempts=5)
         except processutils.ProcessExecutionError as e:
-            self.errors.append(e)
+            if not ignore_err:
+                self.errors.append(e)

--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -1944,7 +1944,8 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
             for bond in self.bond_primary_ifaces:
                 self.ovs_appctl('bond/set-active-slave', bond,
-                                self.bond_primary_ifaces[bond])
+                                self.bond_primary_ifaces[bond],
+                                ignore_err=True)
 
             if ivs_uplinks or ivs_interfaces:
                 logger.info("Attach to ivs with "

--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -1594,8 +1594,14 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                         (bond_name, bond_path, bond_data))
                 update_files[bond_path] = bond_data
             else:
-                logger.info('No changes required for linux bond: %s' %
-                            bond_name)
+                for child in children:
+                    if child in restart_interfaces and \
+                       bond_name not in restart_linux_bonds:
+                        restart_linux_bonds.append(bond_name)
+                        break
+                else:
+                    logger.info('No changes required for linux bond: %s' %
+                                bond_name)
             if utils.diff(bond_route_path, route_data):
                 update_files[bond_route_path] = route_data
                 if bond_name not in restart_linux_bonds:

--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -1003,6 +1003,10 @@ class LinuxBond(_BaseOpts):
         for member in self.members:
             if isinstance(member, SriovPF):
                 utils.update_sriov_pf_map(member.name, member.numvfs, False,
+                                          promisc=member.promisc,
+                                          steering_mode=member.steering_mode,
+                                          link_mode=member.link_mode,
+                                          vdpa=member.vdpa,
                                           lag_candidate=True)
             if isinstance(member, SriovVF):
                 LinuxBond.update_vf_config(member)

--- a/zuul.d/layout.yaml
+++ b/zuul.d/layout.yaml
@@ -11,6 +11,6 @@
       - tripleo-upgrades-master-pipeline
     check:
       jobs:
-        - tripleo-ci-centos-8-content-provider:
+        - tripleo-ci-centos-9-content-provider:
             dependencies:
               - openstack-tox-pep8


### PR DESCRIPTION
The ovs command to set the primary interface of the bond fails when the interface is not active. This patch ignores the error and proceeds with the remaining configuration.

Change-Id: I3592af4f357dca483fc7914133e1fc248d12f11a (cherry picked from commit b4779a6b28e01689025919548ee3ef51c13c8188) (cherry picked from commit 01d1c57596aa0e61f04fbd4008cc43505f06246c)