### PR TITLE
VLANs needs to be restarted when the associated linux bond is restarted

### DIFF
--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -1613,8 +1613,14 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                         (bond_name, bond_path, bond_data))
                 update_files[bond_path] = bond_data
             else:
-                logger.info('No changes required for linux bond: %s' %
-                            bond_name)
+                for child in children:
+                    if child in restart_interfaces and \
+                       bond_name not in restart_linux_bonds:
+                        restart_linux_bonds.append(bond_name)
+                        break
+                else:
+                    logger.info('No changes required for linux bond: %s' %
+                                bond_name)
             if utils.diff(bond_route_path, route_data):
                 update_files[bond_route_path] = route_data
                 if bond_name not in restart_linux_bonds:


### PR DESCRIPTION
Consider the case where 2 interfaces eno1 and eno2 are added as members to linux bond bond1. And vlan100 is created on bond1.  Now when os-net-config is re-run it finds a change in ifcfg-eno1 or ifcfg-eno2. In this case the affected devices would be restarted, which triggers a restart of bond1. In this case the vlan devices associated with the bond shall also be restarted.

Change-Id: If80544262bf3827e5af0c32abcdcc5b6c2e71905 (cherry picked from commit ba37f85889a949b953c53c1085439c49028e3487)