### PR TITLE
execute "ip link set dev <dev> down" if device is still active instead of "ifdown <interface>"

### DIFF
--- a/os_net_config/__init__.py
+++ b/os_net_config/__init__.py
@@ -329,9 +329,10 @@ class NetConfig(object):
         if not self.noop:
             os.remove(filename)
 
-    def ifdown(self, interface, iftype='interface'):
-        msg = 'running ifdown on %s: %s' % (iftype, interface)
-        self.execute(msg, '/sbin/ifdown', interface, check_exit_code=False)
+    def ifdown(self, interface, iftype='interface', cleanup=True):
+        if cleanup:
+            msg = 'running ifdown on %s: %s' % (iftype, interface)
+            self.execute(msg, '/sbin/ifdown', interface, check_exit_code=False)
         if utils.is_active_nic(interface):
             msg = '%s %s is up, trying with ip command' % (iftype, interface)
             self.execute(msg, '/sbin/ip',

--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -1879,7 +1879,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                         break
 
             for vlan in restart_vlans:
-                self.ifdown(vlan)
+                self.ifdown(vlan, iftype='interface', cleanup=cleanup)
 
             for ib_child in restart_ib_childs:
                 self.ifdown(ib_child)


### PR DESCRIPTION
In NCS, we have a feature to add/remove vlan interface/s post install. To activate/deactivate the vlan interface/s, os-net-config was called upon such operation, and os-net-config invokes Linux ifdown command when restarting an interface. Linux ifdown-eth script deletes vlan type of interface/s.

The host level impact is vlan traffic loss. The impact on ipvlan pods is decremental as the ipvlan interfaces in the pods are deleted. Jing Zhang has made changes to os-net-config scripts to avoid vlan deletion when os-net-config is called.
