### PR TITLE
Set the primary hw address for ovs bridge

### DIFF
--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -625,7 +625,7 @@ class OvsInterface(_BaseOpts):
                  routes=None, rules=None, mtu=None, primary=False,
                  nic_mapping=None, persist_mapping=False, defroute=True,
                  dhclient_args=None, dns_servers=None, nm_controlled=False,
-                 onboot=True, domain=None):
+                 onboot=True, domain=None, hwaddr=None):
         addresses = addresses or []
         routes = routes or []
         rules = rules or []
@@ -636,6 +636,7 @@ class OvsInterface(_BaseOpts):
             nic_mapping, persist_mapping, defroute,
             dhclient_args, dns_servers,
             nm_controlled, onboot, domain)
+        self.hwaddr = hwaddr
 
     @staticmethod
     def from_json(json):


### PR DESCRIPTION
The primary hw address of the bridge needs to be set on the OVS interface attached to the bridge instead of the bridge. 