### PR TITLE
Reduce the definition of test stubs for update_sriov_pf_map

### DIFF
--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -1317,6 +1317,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
             be activated by stopping/starting interfaces
             NOTE: if cleanup is specified we will deactivate interfaces even
             if activate is false
+        :param config_rules_dns: A boolean that indicates if the rules should
+            be applied. This makes sure that the rules are configured only if
+            config_rules_dns is set to True.
         :returns: a dict of the format: filename/data which contains info
             for each file that was changed (or would be changed if in --noop
             mode).

--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -1580,6 +1580,9 @@ class NmstateNetConfig(os_net_config.NetConfig):
             be activated by stopping/starting interfaces
             NOTE: if cleanup is specified we will deactivate interfaces even
             if activate is false
+        :param config_rules_dns: A boolean that indicates if the rules should
+            be applied. This makes sure that the rules are configured only if
+            config_rules_dns is set to True.
         :returns: a dict of the format: filename/data which contains info
             for each file that was changed (or would be changed if in --noop
             mode).

--- a/os_net_config/tests/test_cli.py
+++ b/os_net_config/tests/test_cli.py
@@ -47,6 +47,13 @@ class TestCli(base.TestCase):
         self.stub_out('os_net_config.utils.is_ovs_installed',
                       stub_is_ovs_installed)
 
+        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
+                                     link_mode='legacy', vdpa=False,
+                                     steering_mode="smfs"):
+            return
+        self.stub_out('os_net_config.utils.update_sriov_pf_map',
+                      test_update_sriov_pf_map)
+
     def tearDown(self):
         super(TestCli, self).tearDown()
         if os.path.isfile(common._LOG_FILE):
@@ -210,12 +217,6 @@ class TestCli(base.TestCase):
                                            % interface_yaml, exitcodes=(0,))
 
     def test_sriov_noop_output(self):
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
-            return
-        self.stub_out('os_net_config.utils.update_sriov_pf_map',
-                      test_update_sriov_pf_map)
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
@@ -258,12 +259,6 @@ class TestCli(base.TestCase):
         self.assertCountEqual(sriov_config_yaml, sriov_config_json)
 
     def test_sriov_vf_with_dpdk_noop_output(self):
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
-            return
-        self.stub_out('os_net_config.utils.update_sriov_pf_map',
-                      test_update_sriov_pf_map)
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 

--- a/os_net_config/tests/test_objects.py
+++ b/os_net_config/tests/test_objects.py
@@ -1921,13 +1921,17 @@ class TestNicMapping(base.TestCase):
 
 class TestSriovPF(base.TestCase):
 
-    def test_from_json_numvfs(self):
+    def setUp(self):
+        super(TestSriovPF, self).setUp()
+
         def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
                                      link_mode='legacy', vdpa=False,
                                      steering_mode="smfs"):
             return
         self.stub_out('os_net_config.utils.update_sriov_pf_map',
                       test_update_sriov_pf_map)
+
+    def test_from_json_numvfs(self):
         data = '{"type": "sriov_pf", "name": "em1", "numvfs": 16,' \
                '"use_dhcp": false, "promisc": false}'
         pf = objects.object_from_json(json.loads(data))
@@ -1939,16 +1943,6 @@ class TestSriovPF(base.TestCase):
         self.assertIsNone(pf.ethtool_opts)
 
     def test_from_json_numvfs_nic1(self):
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
-            self.assertEqual(name, 'em4')
-            self.assertEqual(numvfs, 16)
-            self.assertEqual(promisc, 'on')
-            self.assertEqual(link_mode, 'legacy')
-        self.stub_out('os_net_config.utils.update_sriov_pf_map',
-                      test_update_sriov_pf_map)
-
         def dummy_mapped_nics(nic_mapping=None):
             return {"nic1": "em4"}
         self.stub_out('os_net_config.objects.mapped_nics', dummy_mapped_nics)
@@ -1962,13 +1956,6 @@ class TestSriovPF(base.TestCase):
         self.assertEqual('on', pf.promisc)
 
     def test_from_json_without_promisc(self):
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
-            return
-        self.stub_out('os_net_config.utils.update_sriov_pf_map',
-                      test_update_sriov_pf_map)
-
         def dummy_mapped_nics(nic_mapping=None):
             return {"nic1": "em4"}
         self.stub_out('os_net_config.objects.mapped_nics', dummy_mapped_nics)
@@ -1982,12 +1969,6 @@ class TestSriovPF(base.TestCase):
         self.assertEqual('on', pf.promisc)
 
     def test_from_json_link_mode(self):
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
-            return
-        self.stub_out('os_net_config.utils.update_sriov_pf_map',
-                          test_update_sriov_pf_map)
         data = '{"type": "sriov_pf", "name": "p6p1", "numvfs": 8,' \
                '"use_dhcp": false, "promisc": false, "link_mode":' \
                '"switchdev"}'
@@ -2019,12 +2000,6 @@ class TestSriovPF(base.TestCase):
         self.assertIn(expected, str(err))
 
     def test_from_json_vdpa_no_numvfs(self):
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
-            return
-        self.stub_out('os_net_config.utils.update_sriov_pf_map',
-                      test_update_sriov_pf_map)
         data = '{"type": "sriov_pf", "name": "p6p1", "numvfs": 0,' \
                '"use_dhcp": false, "promisc": false, "link_mode":' \
                '"switchdev", "vdpa": true}'
@@ -2035,12 +2010,6 @@ class TestSriovPF(base.TestCase):
         self.assertIn(expected, str(err))
 
     def test_from_json_steering_mode_dmfs(self):
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
-            return
-        self.stub_out('os_net_config.utils.update_sriov_pf_map',
-                      test_update_sriov_pf_map)
         data = '{"type": "sriov_pf", "name": "p6p1", "numvfs": 8,' \
                '"use_dhcp": false, "promisc": false, "link_mode":' \
                '"switchdev", "steering_mode": "dmfs"}'
@@ -2053,12 +2022,6 @@ class TestSriovPF(base.TestCase):
         self.assertEqual("dmfs", pf.steering_mode)
 
     def test_from_json_steering_mode_smfs(self):
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
-            return
-        self.stub_out('os_net_config.utils.update_sriov_pf_map',
-                      test_update_sriov_pf_map)
         data = '{"type": "sriov_pf", "name": "p6p1", "numvfs": 8,' \
                '"use_dhcp": false, "promisc": false, "link_mode":' \
                '"switchdev", "steering_mode": "smfs"}'
@@ -2071,13 +2034,6 @@ class TestSriovPF(base.TestCase):
         self.assertEqual("smfs", pf.steering_mode)
 
     def test_from_json_steering_mode_none(self):
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
-            return
-        self.stub_out('os_net_config.utils.update_sriov_pf_map',
-                      test_update_sriov_pf_map)
-
         data = '{"type": "sriov_pf", "name": "p6p1", "numvfs": 8,' \
                '"use_dhcp": false, "promisc": false, "link_mode":' \
                '"switchdev"}'
@@ -2100,12 +2056,6 @@ class TestSriovPF(base.TestCase):
         self.assertIn(expected, str(err))
 
     def test_from_json_ethtool_opts(self):
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
-            return
-        self.stub_out('os_net_config.utils.update_sriov_pf_map',
-                      test_update_sriov_pf_map)
         data = '{"type": "sriov_pf", "name": "em1", "numvfs": 16, ' \
                '"use_dhcp": false, "promisc": false, ' \
                '"ethtool_opts": "speed 1000 duplex full"}'


### PR DESCRIPTION
The stub for update_sriov_pf_map is defined for many test cases in test_objects.py. Reduced the redefinition of the same