### PR TITLE
Add EDPM Zuul Jobs for os-net-config repo

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,7 +1,24 @@
 ---
+- job:
+    name: openstack-services-content-provider
+    parent: cifmw-tcib-base
+    nodeset: centos-stream-9-vexxhost
+    description: |
+      Zuul job to build rpms for openstack projects from opendev, tcib and
+      os-net-config from github. It also builds openstack services container
+      for openstack projects.
+
 - project:
     name: os-net-config/os-net-config
     github-check:
       jobs:
         - tox-linters:
             nodeset: rdo-centos-9-stream
+        - openstack-services-content-provider:
+            files: &_files
+              - ^os_net_config/*.py
+        - podified-multinode-edpm-deployment-crc:
+            override-checkout: main
+            files: *_files
+            dependencies:
+              - openstack-services-content-provider


### PR DESCRIPTION
openstack-services-content-provider will build the os-net-config rpm from the os-net-config pr proposed under test.
    
Then same rpm will be consumed in the edpm job via gating repo. This will allow to test os-net-config changes with the edpm job.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1800