### PR TITLE
Avoid bringing down devices not managed by NM

### DIFF
--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -400,6 +400,10 @@ class NmstateNetConfig(os_net_config.NetConfig):
         for iface in ifaces:
             if Interface.NAME in iface and \
                iface[Interface.NAME] not in exclude_nics:
+                if iface[Interface.STATE] == InterfaceState.IGNORE:
+                    msg=f"Skip cleaning {iface[Interface.NAME]}"
+                    self.__dump_config(state, msg)
+                    continue
                 iface[Interface.STATE] = InterfaceState.DOWN
                 state = {Interface.KEY: [iface]}
                 self.__dump_config(state,


### PR DESCRIPTION
With nmstate provider, during the cleanup operation, avoid bringing down interface which are not managed by NM. The states of these devices cannot be modified by NM and hence avoiding the cleanup and reconfiguration of the same.