### PR TITLE
Enable dcb logs to print in log file

### DIFF
--- a/os_net_config/dcb_config.py
+++ b/os_net_config/dcb_config.py
@@ -509,6 +509,7 @@ def parse_config(user_config_file):
 
 def main(argv=sys.argv):
     opts = parse_opts(argv)
+    common.configure_logger(log_file=True)
     common.logger_level(logger, opts.verbose, opts.debug)
 
     if opts.config_file:


### PR DESCRIPTION
With Day 2 configuration, the dcb logs are not printed in the log file. Setting the required flag enables the logging.

The DCB related logs are not coming in file /var/log/os-net-config.log after DCB config applied through Day 2 configuration. 

After applying the changes in the commit, can see the DCB logs in the log file (/var/log/os-net-config.log)