### PR TITLE
VF parameters are configured with nmstate provider

### DIFF
--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -1630,7 +1630,11 @@ class NmstateNetConfig(os_net_config.NetConfig):
         logger.debug("----------------------------")
         vf_config = self.prepare_sriov_vf_config()
         apply_data = {}
-        apply_data.update(self.set_ifaces(vf_config))
+        if vf_config and activate:
+            if not self.noop:
+                logger.debug("Applying the VF parameters")
+                self.nmstate_apply(self.set_ifaces(vf_config),
+                                   verify=True)
 
         for interface_name, iface_data in self.interface_data.items():
             iface_state = self.iface_state(interface_name)


### PR DESCRIPTION
In case of NIC partitioning the VF parameters are not configured due to the incorrect updation of apply_data dict. The VF parameters are applied separately now.