### PR TITLE
Handle nic mapping for DCB configs

### DIFF
--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -527,9 +527,15 @@ class Interface(_BaseOpts):
         linkdelay = json.get('linkdelay', None)
         dcb_config_json = json.get('dcb')
         if dcb_config_json:
-            dcb_config_json['name'] = name
+            nic_mapping = json.get('nic_mapping', None)
+            mapped_nic_names = mapped_nics(nic_mapping)
+            if name in mapped_nic_names:
+                ifname = mapped_nic_names[name]
+            else:
+                ifname = name
+            dcb_config_json['name'] = ifname
             dcb_config = Dcb.from_json(dcb_config_json)
-            common.update_dcb_map(ifname=name, pci_addr=dcb_config.pci_addr,
+            common.update_dcb_map(ifname=ifname, pci_addr=dcb_config.pci_addr,
                                   driver=dcb_config.driver, noop=False,
                                   dscp2prio=dcb_config.dscp2prio)
 
@@ -1683,9 +1689,15 @@ class SriovPF(_BaseOpts):
 
         dcb_config_json = json.get('dcb')
         if dcb_config_json:
-            dcb_config_json['name'] = name
+            nic_mapping = json.get('nic_mapping', None)
+            mapped_nic_names = mapped_nics(nic_mapping)
+            if name in mapped_nic_names:
+                ifname = mapped_nic_names[name]
+            else:
+                ifname = name
+            dcb_config_json['name'] = ifname
             dcb_config = Dcb.from_json(dcb_config_json)
-            common.update_dcb_map(ifname=name, pci_addr=dcb_config.pci_addr,
+            common.update_dcb_map(ifname=ifname, pci_addr=dcb_config.pci_addr,
                                   driver=dcb_config.driver, noop=False,
                                   dscp2prio=dcb_config.dscp2prio)
 


### PR DESCRIPTION
As part of deployment templates the nic numbering
is being used and for DCB configs it is not supported and expecting physical interface naming. Hence adding changes to use the mapping of the nics to appropriate interfaces for DCB configs, so that it can support with nic numbering.

Changes are done and tested as below. Logs shared for reference.
[cloud-admin@rhos-nfv-10 ~]$ sudo os-net-config -d 
2024-07-17 10:32:13.094 INFO os_net_config.main Using config file at: /etc/os-net-config/config.yaml
2024-07-17 10:32:13.095 INFO os_net_config.impl_ifcfg.__init__ Ifcfg net config provider created.
2024-07-17 10:32:13.095 INFO os_net_config.main Using mapping file at: /etc/os-net-config/mapping.yaml
2024-07-17 10:32:13.096 DEBUG os_net_config.main interface_mapping: {'nic1': 'e4:43:4b:4d:ec:64', 'nic2': 'e4:43:4b:4d:ec:46', 'nic3': '04:3f:72:d9:c0:44', 'nic4': '04:3f:72:d9:c0:45', 'nic5': 'e4:43:4b:4d:ec:44', 'nic6': 'e4:43:4b:4d:ec:65'}
2024-07-17 10:32:13.096 DEBUG os_net_config.main persist_mapping: False
2024-07-17 10:32:13.108 DEBUG os_net_config.main network_config: [{'type': 'linux_bond', 'name': 'bond_api', 'use_dhcp': False, 'bonding_options': 'mode=active-backup', 'dns_servers': ['192.168.122.80'], 'addresses': [{'ip_netmask': '192.168.122.101/24'}], 'routes': [{'default': True, 'next_hop': '192.168.122.1'}], 'members': [{'type': 'interface', 'name': 'nic2', 'primary': True}]}, {'type': 'vlan', 'vlan_id': 202, 'device': 'bond_api', 'addresses': [{'ip_netmask': '172.17.0.100/24'}], 'routes': []}, {'type': 'vlan', 'vlan_id': 203, 'device': 'bond_api', 'addresses': [{'ip_netmask': '172.18.0.100/24'}], 'routes': []}, {'type': 'ovs_user_bridge', 'name': 'br-link1', 'use_dhcp': False, 'mtu': 9000, 'members': [{'type': 'ovs_dpdk_port', 'name': 'dpdk1', 'driver': 'mlx5_core', 'mtu': 9000, 'members': [{'type': 'interface', 'name': 'nic3', 'dcb': {'dscp2prio': [{'priority': 2, 'protocol': 24}, {'priority': 3, 'protocol': 8}, {'priority': 4, 'protocol': 12}]}}]}]}, {'type': 'ovs_user_bridge', 'name': 'br-link2', 'use_dhcp': False, 'mtu': 9000, 'members': [{'type': 'ovs_dpdk_port', 'name': 'dpdk2', 'driver': 'mlx5_core', 'members': [{'type': 'interface', 'name': 'nic4', 'dcb': {'dscp2prio': [{'priority': 2, 'protocol': 24}, {'priority': 3, 'protocol': 8}, {'priority': 4, 'protocol': 12}]}}]}]}, {'type': 'interface', 'name': 'nic5', 'use_dhcp': False, 'use_dhcpv6': False}, {'type': 'interface', 'name': 'nic6', 'use_dhcp': False, 'use_dhcpv6': False}, {'type': 'interface', 'name': 'nic1', 'use_dhcp': True, 'use_dhcpv6': False}]
2024-07-17 10:32:13.386 INFO os_net_config.utils._ordered_nics Finding active nics
2024-07-17 10:32:13.387 INFO os_net_config.utils._ordered_nics enp4s0f1np1 is an active nic
2024-07-17 10:32:13.387 INFO os_net_config.utils._ordered_nics bonding_masters is not an active nic
2024-07-17 10:32:13.387 INFO os_net_config.utils._ordered_nics eno4 is an embedded active nic
2024-07-17 10:32:13.387 INFO os_net_config.utils._ordered_nics br-link2 is not an active nic
2024-07-17 10:32:13.388 INFO os_net_config.utils._ordered_nics lo is not an active nic
2024-07-17 10:32:13.388 INFO os_net_config.utils._ordered_nics eno2 is an embedded active nic
2024-07-17 10:32:13.388 INFO os_net_config.utils._ordered_nics tap27ad006e-80 is not an active nic
2024-07-17 10:32:13.388 INFO os_net_config.utils._ordered_nics vlan202 is not an active nic
2024-07-17 10:32:13.388 INFO os_net_config.utils._ordered_nics br-int is not an active nic
2024-07-17 10:32:13.388 INFO os_net_config.utils._ordered_nics ovs-netdev is not an active nic
2024-07-17 10:32:13.389 INFO os_net_config.utils._ordered_nics eno3 is an embedded active nic
2024-07-17 10:32:13.389 INFO os_net_config.utils._ordered_nics br-link1 is not an active nic
2024-07-17 10:32:13.389 INFO os_net_config.utils._ordered_nics eno1 is an embedded active nic
2024-07-17 10:32:13.389 INFO os_net_config.utils._ordered_nics bond_api is not an active nic
2024-07-17 10:32:13.390 INFO os_net_config.utils._ordered_nics enp4s0f0np0 is an active nic
2024-07-17 10:32:13.390 INFO os_net_config.utils._ordered_nics vlan203 is not an active nic
2024-07-17 10:32:13.391 INFO os_net_config.utils._ordered_nics enp4s0f0np0 is an DPDK bound nic
2024-07-17 10:32:13.391 INFO os_net_config.utils._ordered_nics enp4s0f1np1 is an DPDK bound nic
2024-07-17 10:32:13.391 INFO os_net_config.utils._ordered_nics Active nics are ['eno1', 'eno2', 'eno3', 'eno4', 'enp4s0f0np0', 'enp4s0f1np1']
2024-07-17 10:32:13.392 DEBUG os_net_config.objects.mapped_nics e4:43:4b:4d:ec:64 matches device eno3
2024-07-17 10:32:13.392 INFO os_net_config.objects.mapped_nics nic1 in mapping file mapped to: eno3
2024-07-17 10:32:13.392 DEBUG os_net_config.objects.mapped_nics e4:43:4b:4d:ec:46 matches device eno2
2024-07-17 10:32:13.392 INFO os_net_config.objects.mapped_nics nic2 in mapping file mapped to: eno2
2024-07-17 10:32:13.393 DEBUG os_net_config.objects.mapped_nics 04:3f:72:d9:c0:44 matches device enp4s0f0np0
2024-07-17 10:32:13.393 INFO os_net_config.objects.mapped_nics nic3 in mapping file mapped to: enp4s0f0np0
2024-07-17 10:32:13.393 DEBUG os_net_config.objects.mapped_nics 04:3f:72:d9:c0:45 matches device enp4s0f1np1
2024-07-17 10:32:13.393 INFO os_net_config.objects.mapped_nics nic4 in mapping file mapped to: enp4s0f1np1
2024-07-17 10:32:13.393 DEBUG os_net_config.objects.mapped_nics e4:43:4b:4d:ec:44 matches device eno1
2024-07-17 10:32:13.394 INFO os_net_config.objects.mapped_nics nic5 in mapping file mapped to: eno1
2024-07-17 10:32:13.394 DEBUG os_net_config.objects.mapped_nics e4:43:4b:4d:ec:65 matches device eno4
2024-07-17 10:32:13.394 INFO os_net_config.objects.mapped_nics nic6 in mapping file mapped to: eno4
2024-07-17 10:32:13.394 INFO os_net_config.utils._ordered_nics Finding active nics
2024-07-17 10:32:13.394 INFO os_net_config.utils._ordered_nics enp4s0f1np1 is an active nic
2024-07-17 10:32:13.394 INFO os_net_config.utils._ordered_nics bonding_masters is not an active nic
2024-07-17 10:32:13.395 INFO os_net_config.utils._ordered_nics eno4 is an embedded active nic
2024-07-17 10:32:13.395 INFO os_net_config.utils._ordered_nics br-link2 is not an active nic
2024-07-17 10:32:13.395 INFO os_net_config.utils._ordered_nics lo is not an active nic
2024-07-17 10:32:13.395 INFO os_net_config.utils._ordered_nics eno2 is an embedded active nic
2024-07-17 10:32:13.395 INFO os_net_config.utils._ordered_nics tap27ad006e-80 is not an active nic
2024-07-17 10:32:13.395 INFO os_net_config.utils._ordered_nics vlan202 is not an active nic
2024-07-17 10:32:13.395 INFO os_net_config.utils._ordered_nics br-int is not an active nic
2024-07-17 10:32:13.396 INFO os_net_config.utils._ordered_nics ovs-netdev is not an active nic
2024-07-17 10:32:13.396 INFO os_net_config.utils._ordered_nics eno3 is an embedded active nic
2024-07-17 10:32:13.396 INFO os_net_config.utils._ordered_nics br-link1 is not an active nic
2024-07-17 10:32:13.396 INFO os_net_config.utils._ordered_nics eno1 is an embedded active nic
2024-07-17 10:32:13.397 INFO os_net_config.utils._ordered_nics bond_api is not an active nic
2024-07-17 10:32:13.397 INFO os_net_config.utils._ordered_nics enp4s0f0np0 is an active nic
2024-07-17 10:32:13.397 INFO os_net_config.utils._ordered_nics vlan203 is not an active nic
2024-07-17 10:32:13.398 INFO os_net_config.utils._ordered_nics enp4s0f0np0 is an DPDK bound nic
2024-07-17 10:32:13.399 INFO os_net_config.utils._ordered_nics enp4s0f1np1 is an DPDK bound nic
2024-07-17 10:32:13.399 INFO os_net_config.utils._ordered_nics Active nics are ['eno1', 'eno2', 'eno3', 'eno4', 'enp4s0f0np0', 'enp4s0f1np1']
2024-07-17 10:32:13.423 INFO os_net_config.impl_ifcfg.add_linux_bond adding linux bond: bond_api
2024-07-17 10:32:13.423 DEBUG os_net_config.impl_ifcfg.add_linux_bond bond data: # This file is autogenerated by os-net-config
DEVICE=bond_api
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
MACADDR="e4:43:4b:4d:ec:46"
BONDING_OPTS="mode=active-backup"
BOOTPROTO=static
IPADDR=192.168.122.101
NETMASK=255.255.255.0
DNS1=192.168.122.80

2024-07-17 10:32:13.423 INFO os_net_config.impl_ifcfg._add_routes adding custom route for interface: bond_api
2024-07-17 10:32:13.423 DEBUG os_net_config.impl_ifcfg._add_routes route data: default via 192.168.122.1 dev bond_api

2024-07-17 10:32:13.423 DEBUG os_net_config.impl_ifcfg._add_routes ipv6 route data: 
2024-07-17 10:32:13.423 INFO os_net_config.impl_ifcfg.add_interface adding interface: eno2
2024-07-17 10:32:13.424 DEBUG os_net_config.impl_ifcfg.add_interface interface data: # This file is autogenerated by os-net-config
DEVICE=eno2
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
MASTER=bond_api
SLAVE=yes
BOOTPROTO=none

2024-07-17 10:32:13.424 INFO os_net_config.impl_ifcfg.add_vlan adding vlan: vlan202
2024-07-17 10:32:13.424 DEBUG os_net_config.impl_ifcfg.add_vlan vlan data: # This file is autogenerated by os-net-config
DEVICE=vlan202
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
VLAN=yes
PHYSDEV=bond_api
BOOTPROTO=static
IPADDR=172.17.0.100
NETMASK=255.255.255.0

2024-07-17 10:32:13.424 INFO os_net_config.impl_ifcfg.add_vlan adding vlan: vlan203
2024-07-17 10:32:13.424 DEBUG os_net_config.impl_ifcfg.add_vlan vlan data: # This file is autogenerated by os-net-config
DEVICE=vlan203
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
VLAN=yes
PHYSDEV=bond_api
BOOTPROTO=static
IPADDR=172.18.0.100
NETMASK=255.255.255.0

2024-07-17 10:32:13.437 INFO os_net_config.impl_ifcfg.add_ovs_user_bridge adding ovs user bridge: br-link1
2024-07-17 10:32:13.437 DEBUG os_net_config.impl_ifcfg.add_ovs_user_bridge ovs user bridge data: # This file is autogenerated by os-net-config
DEVICE=br-link1
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
DEVICETYPE=ovs
TYPE=OVSUserBridge
MTU=9000
OVS_EXTRA="set bridge br-link1 fail_mode=standalone -- del-controller br-link1"

2024-07-17 10:32:13.438 INFO os_net_config.impl_ifcfg.add_ovs_dpdk_port adding ovs dpdk port: dpdk1
2024-07-17 10:32:13.442 INFO os_net_config.common.set_driverctl_override Driver mlx5_core is already bound to the device{pci_address}
2024-07-17 10:32:13.449 INFO os_net_config.utils.get_dpdk_devargs Getting devargs for Mellanox cards
2024-07-17 10:32:13.453 DEBUG os_net_config.utils.get_dpdk_devargs Devargs found: 0000:04:00.0
2024-07-17 10:32:13.453 DEBUG os_net_config.impl_ifcfg.add_ovs_dpdk_port ovs dpdk port data: # This file is autogenerated by os-net-config
DEVICE=dpdk1
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
DEVICETYPE=ovs
TYPE=OVSDPDKPort
OVS_BRIDGE=br-link1
MTU=9000
OVS_EXTRA="set Interface $DEVICE options:dpdk-devargs=0000:04:00.0 -- set Interface $DEVICE mtu_request=$MTU"

2024-07-17 10:32:13.453 INFO os_net_config.impl_ifcfg.add_interface adding interface: enp4s0f0np0
2024-07-17 10:32:13.453 DEBUG os_net_config.impl_ifcfg.add_interface interface data: # This file is autogenerated by os-net-config
DEVICE=enp4s0f0np0
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
BOOTPROTO=none

2024-07-17 10:32:13.467 INFO os_net_config.impl_ifcfg.add_ovs_user_bridge adding ovs user bridge: br-link2
2024-07-17 10:32:13.467 DEBUG os_net_config.impl_ifcfg.add_ovs_user_bridge ovs user bridge data: # This file is autogenerated by os-net-config
DEVICE=br-link2
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
DEVICETYPE=ovs
TYPE=OVSUserBridge
MTU=9000
OVS_EXTRA="set bridge br-link2 fail_mode=standalone -- del-controller br-link2"

2024-07-17 10:32:13.467 INFO os_net_config.impl_ifcfg.add_ovs_dpdk_port adding ovs dpdk port: dpdk2
2024-07-17 10:32:13.471 INFO os_net_config.common.set_driverctl_override Driver mlx5_core is already bound to the device{pci_address}
2024-07-17 10:32:13.477 INFO os_net_config.utils.get_dpdk_devargs Getting devargs for Mellanox cards
2024-07-17 10:32:13.480 DEBUG os_net_config.utils.get_dpdk_devargs Devargs found: 0000:04:00.1
2024-07-17 10:32:13.480 DEBUG os_net_config.impl_ifcfg.add_ovs_dpdk_port ovs dpdk port data: # This file is autogenerated by os-net-config
DEVICE=dpdk2
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
DEVICETYPE=ovs
TYPE=OVSDPDKPort
OVS_BRIDGE=br-link2
OVS_EXTRA="set Interface $DEVICE options:dpdk-devargs=0000:04:00.1"

2024-07-17 10:32:13.481 INFO os_net_config.impl_ifcfg.add_interface adding interface: enp4s0f1np1
2024-07-17 10:32:13.481 DEBUG os_net_config.impl_ifcfg.add_interface interface data: # This file is autogenerated by os-net-config
DEVICE=enp4s0f1np1
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
BOOTPROTO=none

2024-07-17 10:32:13.481 INFO os_net_config.impl_ifcfg.add_interface adding interface: eno1
2024-07-17 10:32:13.481 DEBUG os_net_config.impl_ifcfg.add_interface interface data: # This file is autogenerated by os-net-config
DEVICE=eno1
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
BOOTPROTO=none

2024-07-17 10:32:13.481 INFO os_net_config.impl_ifcfg.add_interface adding interface: eno4
2024-07-17 10:32:13.481 DEBUG os_net_config.impl_ifcfg.add_interface interface data: # This file is autogenerated by os-net-config
DEVICE=eno4
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
BOOTPROTO=none

2024-07-17 10:32:13.481 INFO os_net_config.impl_ifcfg.add_interface adding interface: eno3
2024-07-17 10:32:13.482 DEBUG os_net_config.impl_ifcfg.add_interface interface data: # This file is autogenerated by os-net-config
DEVICE=eno3
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
BOOTPROTO=dhcp

2024-07-17 10:32:13.482 INFO os_net_config.impl_ifcfg.apply applying network configs...
2024-07-17 10:32:13.482 DEBUG os_net_config.utils.diff Diff file data:
# This file is autogenerated by os-net-config
DEVICE=eno2
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
MASTER=bond_api
SLAVE=yes
BOOTPROTO=none

2024-07-17 10:32:13.482 DEBUG os_net_config.utils.diff Diff data:
# This file is autogenerated by os-net-config
DEVICE=eno2
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
MASTER=bond_api
SLAVE=yes
BOOTPROTO=none

2024-07-17 10:32:13.482 INFO os_net_config.impl_ifcfg.apply No changes required for interface: eno2
2024-07-17 10:32:13.482 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.482 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.482 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.482 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.483 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.483 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.483 DEBUG os_net_config.utils.diff Diff file data:
# This file is autogenerated by os-net-config
DEVICE=dpdk1
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
DEVICETYPE=ovs
TYPE=OVSDPDKPort
OVS_BRIDGE=br-link1
OVS_EXTRA="set Interface $DEVICE options:dpdk-devargs=0000:04:00.0"

2024-07-17 10:32:13.483 DEBUG os_net_config.utils.diff Diff data:
# This file is autogenerated by os-net-config
DEVICE=dpdk1
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
DEVICETYPE=ovs
TYPE=OVSDPDKPort
OVS_BRIDGE=br-link1
MTU=9000
OVS_EXTRA="set Interface $DEVICE options:dpdk-devargs=0000:04:00.0 -- set Interface $DEVICE mtu_request=$MTU"

2024-07-17 10:32:13.483 DEBUG os_net_config.impl_ifcfg.ifcfg_requires_restart Original ifcfg file:
# This file is autogenerated by os-net-config
DEVICE=dpdk1
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
DEVICETYPE=ovs
TYPE=OVSDPDKPort
OVS_BRIDGE=br-link1
OVS_EXTRA="set Interface $DEVICE options:dpdk-devargs=0000:04:00.0"

2024-07-17 10:32:13.483 DEBUG os_net_config.impl_ifcfg.ifcfg_requires_restart New ifcfg file:
# This file is autogenerated by os-net-config
DEVICE=dpdk1
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
DEVICETYPE=ovs
TYPE=OVSDPDKPort
OVS_BRIDGE=br-link1
MTU=9000
OVS_EXTRA="set Interface $DEVICE options:dpdk-devargs=0000:04:00.0 -- set Interface $DEVICE mtu_request=$MTU"

2024-07-17 10:32:13.483 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.483 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.483 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.483 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.484 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.484 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.484 DEBUG os_net_config.utils.diff Diff file data:
# This file is autogenerated by os-net-config
DEVICE=enp4s0f0np0
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
BOOTPROTO=none

2024-07-17 10:32:13.484 DEBUG os_net_config.utils.diff Diff data:
# This file is autogenerated by os-net-config
DEVICE=enp4s0f0np0
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
BOOTPROTO=none

2024-07-17 10:32:13.484 INFO os_net_config.impl_ifcfg.apply No changes required for interface: enp4s0f0np0
2024-07-17 10:32:13.484 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.484 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.484 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.484 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.484 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.484 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.485 DEBUG os_net_config.utils.diff Diff file data:
# This file is autogenerated by os-net-config
DEVICE=dpdk2
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
DEVICETYPE=ovs
TYPE=OVSDPDKPort
OVS_BRIDGE=br-link2
OVS_EXTRA="set Interface $DEVICE options:dpdk-devargs=0000:04:00.1"

2024-07-17 10:32:13.485 DEBUG os_net_config.utils.diff Diff data:
# This file is autogenerated by os-net-config
DEVICE=dpdk2
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
DEVICETYPE=ovs
TYPE=OVSDPDKPort
OVS_BRIDGE=br-link2
OVS_EXTRA="set Interface $DEVICE options:dpdk-devargs=0000:04:00.1"

2024-07-17 10:32:13.485 INFO os_net_config.impl_ifcfg.apply No changes required for interface: dpdk2
2024-07-17 10:32:13.485 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.485 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.485 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.485 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.485 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.485 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.485 DEBUG os_net_config.utils.diff Diff file data:
# This file is autogenerated by os-net-config
DEVICE=enp4s0f1np1
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
BOOTPROTO=none

2024-07-17 10:32:13.485 DEBUG os_net_config.utils.diff Diff data:
# This file is autogenerated by os-net-config
DEVICE=enp4s0f1np1
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
BOOTPROTO=none

2024-07-17 10:32:13.485 INFO os_net_config.impl_ifcfg.apply No changes required for interface: enp4s0f1np1
2024-07-17 10:32:13.486 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.486 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.486 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.486 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.486 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.486 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.486 DEBUG os_net_config.utils.diff Diff file data:
# This file is autogenerated by os-net-config
DEVICE=eno1
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
BOOTPROTO=none

2024-07-17 10:32:13.486 DEBUG os_net_config.utils.diff Diff data:
# This file is autogenerated by os-net-config
DEVICE=eno1
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
BOOTPROTO=none

2024-07-17 10:32:13.486 INFO os_net_config.impl_ifcfg.apply No changes required for interface: eno1
2024-07-17 10:32:13.486 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.486 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.486 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.487 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.487 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.487 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.487 DEBUG os_net_config.utils.diff Diff file data:
# This file is autogenerated by os-net-config
DEVICE=eno4
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
BOOTPROTO=none

2024-07-17 10:32:13.487 DEBUG os_net_config.utils.diff Diff data:
# This file is autogenerated by os-net-config
DEVICE=eno4
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
BOOTPROTO=none

2024-07-17 10:32:13.487 INFO os_net_config.impl_ifcfg.apply No changes required for interface: eno4
2024-07-17 10:32:13.487 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.487 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.487 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.487 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.487 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.487 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.488 DEBUG os_net_config.utils.diff Diff file data:
# This file is autogenerated by os-net-config
DEVICE=eno3
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
BOOTPROTO=dhcp

2024-07-17 10:32:13.488 DEBUG os_net_config.utils.diff Diff data:
# This file is autogenerated by os-net-config
DEVICE=eno3
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
BOOTPROTO=dhcp

2024-07-17 10:32:13.488 INFO os_net_config.impl_ifcfg.apply No changes required for interface: eno3
2024-07-17 10:32:13.488 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.488 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.488 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.488 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.488 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.488 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.488 DEBUG os_net_config.utils.diff Diff file data:
# This file is autogenerated by os-net-config
DEVICE=br-link1
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
DEVICETYPE=ovs
TYPE=OVSUserBridge
MTU=9000
OVS_EXTRA="set bridge br-link1 fail_mode=standalone -- del-controller br-link1"

2024-07-17 10:32:13.488 DEBUG os_net_config.utils.diff Diff data:
# This file is autogenerated by os-net-config
DEVICE=br-link1
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
DEVICETYPE=ovs
TYPE=OVSUserBridge
MTU=9000
OVS_EXTRA="set bridge br-link1 fail_mode=standalone -- del-controller br-link1"

2024-07-17 10:32:13.488 INFO os_net_config.impl_ifcfg.apply No changes required for bridge: br-link1
2024-07-17 10:32:13.488 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.489 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.489 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.489 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.489 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.489 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.489 DEBUG os_net_config.utils.diff Diff file data:
# This file is autogenerated by os-net-config
DEVICE=br-link2
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
DEVICETYPE=ovs
TYPE=OVSUserBridge
MTU=9000
OVS_EXTRA="set bridge br-link2 fail_mode=standalone -- del-controller br-link2"

2024-07-17 10:32:13.489 DEBUG os_net_config.utils.diff Diff data:
# This file is autogenerated by os-net-config
DEVICE=br-link2
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
DEVICETYPE=ovs
TYPE=OVSUserBridge
MTU=9000
OVS_EXTRA="set bridge br-link2 fail_mode=standalone -- del-controller br-link2"

2024-07-17 10:32:13.489 INFO os_net_config.impl_ifcfg.apply No changes required for bridge: br-link2
2024-07-17 10:32:13.489 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.489 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.489 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.490 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.490 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.490 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.490 DEBUG os_net_config.utils.diff Diff file data:
# This file is autogenerated by os-net-config
DEVICE=bond_api
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
MACADDR="e4:43:4b:4d:ec:46"
BONDING_OPTS="mode=active-backup"
BOOTPROTO=static
IPADDR=192.168.122.101
NETMASK=255.255.255.0
DNS1=192.168.122.80

2024-07-17 10:32:13.490 DEBUG os_net_config.utils.diff Diff data:
# This file is autogenerated by os-net-config
DEVICE=bond_api
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
MACADDR="e4:43:4b:4d:ec:46"
BONDING_OPTS="mode=active-backup"
BOOTPROTO=static
IPADDR=192.168.122.101
NETMASK=255.255.255.0
DNS1=192.168.122.80

2024-07-17 10:32:13.490 INFO os_net_config.impl_ifcfg.apply No changes required for linux bond: bond_api
2024-07-17 10:32:13.490 DEBUG os_net_config.utils.diff Diff file data:
default via 192.168.122.1 dev bond_api

2024-07-17 10:32:13.490 DEBUG os_net_config.utils.diff Diff data:
default via 192.168.122.1 dev bond_api

2024-07-17 10:32:13.490 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.490 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.491 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.491 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.491 DEBUG os_net_config.utils.diff Diff file data:
# This file is autogenerated by os-net-config
DEVICE=vlan202
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
VLAN=yes
PHYSDEV=bond_api
BOOTPROTO=static
IPADDR=172.17.0.100
NETMASK=255.255.255.0

2024-07-17 10:32:13.491 DEBUG os_net_config.utils.diff Diff data:
# This file is autogenerated by os-net-config
DEVICE=vlan202
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
VLAN=yes
PHYSDEV=bond_api
BOOTPROTO=static
IPADDR=172.17.0.100
NETMASK=255.255.255.0

2024-07-17 10:32:13.491 INFO os_net_config.impl_ifcfg.apply No changes required for vlan interface: vlan202
2024-07-17 10:32:13.491 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.491 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.491 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.491 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.491 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.492 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.492 DEBUG os_net_config.utils.diff Diff file data:
# This file is autogenerated by os-net-config
DEVICE=vlan203
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
VLAN=yes
PHYSDEV=bond_api
BOOTPROTO=static
IPADDR=172.18.0.100
NETMASK=255.255.255.0

2024-07-17 10:32:13.492 DEBUG os_net_config.utils.diff Diff data:
# This file is autogenerated by os-net-config
DEVICE=vlan203
ONBOOT=yes
HOTPLUG=no
NM_CONTROLLED=no
PEERDNS=no
VLAN=yes
PHYSDEV=bond_api
BOOTPROTO=static
IPADDR=172.18.0.100
NETMASK=255.255.255.0

2024-07-17 10:32:13.492 INFO os_net_config.impl_ifcfg.apply No changes required for vlan interface: vlan203
2024-07-17 10:32:13.492 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.492 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.492 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.492 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.492 DEBUG os_net_config.utils.diff Diff file data:

2024-07-17 10:32:13.492 DEBUG os_net_config.utils.diff Diff data:

2024-07-17 10:32:13.492 INFO os_net_config.execute running ifdown on interface: dpdk1
2024-07-17 10:32:13.693 INFO os_net_config.execute Restart openvswitch
2024-07-17 10:32:17.648 INFO os_net_config.write_config Writing config /etc/sysconfig/network-scripts/ifcfg-dpdk1
2024-07-17 10:32:17.649 DEBUG os_net_config.impl_ifcfg.apply Calling stop_dhclient_interfaces() for dpdk1
2024-07-17 10:32:17.649 INFO os_net_config.execute running ifup on interface: dpdk1
2024-07-17 10:32:21.669 DEBUG os_net_config.send_and_receive Sending message RTM_GETDCB cmd DCB_CMD_GDCBX attr []
2024-07-17 10:32:21.670 DEBUG os_net_config.send_and_receive Received message {'family': 0, 'cmd': 22, 'pad': 0, 'attrs': [('DCB_ATTR_DCBX', 12)], 'header': {'length': 28, 'type': 78, 'flags': 1, 'sequence_number': 1, 'pid': 326272}}
2024-07-17 10:32:21.670 DEBUG os_net_config.get_dcbx DCBX mode for enp4s0f0np0 is 12
2024-07-17 10:32:21.670 DEBUG os_net_config.set_dcbx Setting DCBX mode for enp4s0f0np0                       mode:['DCB_ATTR_DCBX', 0]
2024-07-17 10:32:21.670 DEBUG os_net_config.send_and_receive Sending message RTM_SETDCB cmd DCB_CMD_SDCBX attr [['DCB_ATTR_DCBX', 0]]
2024-07-17 10:32:21.670 DEBUG os_net_config.send_and_receive Received message {'family': 0, 'cmd': 23, 'pad': 0, 'attrs': [('DCB_ATTR_DCBX', 0)], 'header': {'length': 28, 'type': 79, 'flags': 1, 'sequence_number': 2, 'pid': 326272}}
2024-07-17 10:32:21.670 DEBUG os_net_config.set_dcbx Got DCBX mode for enp4s0f0np0 mode:0
2024-07-17 10:32:21.671 DEBUG os_net_config.send_and_receive Sending message RTM_GETDCB cmd DCB_CMD_IEEE_GET attr []
2024-07-17 10:32:21.673 DEBUG os_net_config.send_and_receive Received message {'family': 0, 'cmd': 21, 'pad': 0, 'attrs': [('DCB_ATTR_IFNAME', 'enp4s0f0np0'), ('DCB_ATTR_IEEE', {'attrs': [('DCB_ATTR_IEEE_ETS', {'willing': 0, 'ets_cap': 8, 'cbs': 0, 'tc_tx_bw': (20, 20, 60, 100, 100, 100, 100, 100), 'tc_rx_bw': (0, 0, 0, 0, 0, 0, 0, 0), 'tc_tsa': (2, 2, 2, 255, 255, 255, 255, 255), 'prio_tc': (1, 2, 2, 0, 1, 2, 2, 0), 'tc_reco_bw': (0, 0, 0, 0, 0, 0, 0, 0), 'tc_reco_tsa': (0, 0, 0, 0, 0, 0, 0, 0), 'reco_prio_tc': (0, 0, 0, 0, 0, 0, 0, 0)}), ('UNKNOWN', {'header': {'length': 68, 'type': 7}}), ('DCB_ATTR_IEEE_PFC', {'pfc_cap': 8, 'pfc_en': 0, 'mbc': 0, 'delay': 1792, 'requests': (0, 0, 0, 0, 0, 0, 0, 0), 'indications': (0, 0, 0, 0, 0, 0, 0, 0)}), ('UNKNOWN', {'header': {'length': 48, 'type': 10}}), ('DCB_ATTR_IEEE_APP_TABLE', {'attrs': []})]}), ('DCB_ATTR_DCBX', 12)], 'header': {'length': 372, 'type': 78, 'flags': 1, 'sequence_number': 3, 'pid': 326272}}
2024-07-17 10:32:21.673 DEBUG os_net_config.apply Adding DcbApp {Priority: 2 Protocol: 24 Selector: 5}
2024-07-17 10:32:21.673 DEBUG os_net_config.apply Adding DcbApp {Priority: 3 Protocol: 8 Selector: 5}
2024-07-17 10:32:21.674 DEBUG os_net_config.apply Adding DcbApp {Priority: 4 Protocol: 12 Selector: 5}
2024-07-17 10:32:21.674 DEBUG os_net_config.set_ieee_app Adding ieee app {'selector': 5, 'priority': 2, 'protocol': 24}
2024-07-17 10:32:21.674 DEBUG os_net_config.send_and_receive Sending message RTM_SETDCB cmd DCB_CMD_IEEE_SET attr [['DCB_ATTR_IEEE', {'attrs': [['DCB_ATTR_IEEE_APP_TABLE', {'attrs': [['DCB_ATTR_IEEE_APP', {'selector': 5, 'priority': 2, 'protocol': 24}]]}]]}]]
2024-07-17 10:32:21.676 DEBUG os_net_config.send_and_receive Received message {'family': 0, 'cmd': 20, 'pad': 0, 'attrs': [('DCB_ATTR_IEEE', {'attrs': []})], 'header': {'length': 28, 'type': 79, 'flags': 1, 'sequence_number': 4, 'pid': 326272}}
2024-07-17 10:32:21.676 DEBUG os_net_config.set_ieee_app Adding ieee app {'selector': 5, 'priority': 3, 'protocol': 8}
2024-07-17 10:32:21.677 DEBUG os_net_config.send_and_receive Sending message RTM_SETDCB cmd DCB_CMD_IEEE_SET attr [['DCB_ATTR_IEEE', {'attrs': [['DCB_ATTR_IEEE_APP_TABLE', {'attrs': [['DCB_ATTR_IEEE_APP', {'selector': 5, 'priority': 3, 'protocol': 8}]]}]]}]]
2024-07-17 10:32:21.679 DEBUG os_net_config.send_and_receive Received message {'family': 0, 'cmd': 20, 'pad': 0, 'attrs': [('DCB_ATTR_IEEE', {'attrs': []})], 'header': {'length': 28, 'type': 79, 'flags': 1, 'sequence_number': 5, 'pid': 326272}}
2024-07-17 10:32:21.679 DEBUG os_net_config.set_ieee_app Adding ieee app {'selector': 5, 'priority': 4, 'protocol': 12}
2024-07-17 10:32:21.679 DEBUG os_net_config.send_and_receive Sending message RTM_SETDCB cmd DCB_CMD_IEEE_SET attr [['DCB_ATTR_IEEE', {'attrs': [['DCB_ATTR_IEEE_APP_TABLE', {'attrs': [['DCB_ATTR_IEEE_APP', {'selector': 5, 'priority': 4, 'protocol': 12}]]}]]}]]
2024-07-17 10:32:21.681 DEBUG os_net_config.send_and_receive Received message {'family': 0, 'cmd': 20, 'pad': 0, 'attrs': [('DCB_ATTR_IEEE', {'attrs': []})], 'header': {'length': 28, 'type': 79, 'flags': 1, 'sequence_number': 6, 'pid': 326272}}
2024-07-17 10:32:21.681 DEBUG os_net_config.send_and_receive Sending message RTM_GETDCB cmd DCB_CMD_GDCBX attr []
2024-07-17 10:32:21.681 DEBUG os_net_config.send_and_receive Received message {'family': 0, 'cmd': 22, 'pad': 0, 'attrs': [('DCB_ATTR_DCBX', 12)], 'header': {'length': 28, 'type': 78, 'flags': 1, 'sequence_number': 1, 'pid': 4520576}}
2024-07-17 10:32:21.682 DEBUG os_net_config.get_dcbx DCBX mode for enp4s0f1np1 is 12
2024-07-17 10:32:21.682 DEBUG os_net_config.set_dcbx Setting DCBX mode for enp4s0f1np1                       mode:['DCB_ATTR_DCBX', 0]
2024-07-17 10:32:21.682 DEBUG os_net_config.send_and_receive Sending message RTM_SETDCB cmd DCB_CMD_SDCBX attr [['DCB_ATTR_DCBX', 0]]
2024-07-17 10:32:21.682 DEBUG os_net_config.send_and_receive Received message {'family': 0, 'cmd': 23, 'pad': 0, 'attrs': [('DCB_ATTR_DCBX', 0)], 'header': {'length': 28, 'type': 79, 'flags': 1, 'sequence_number': 2, 'pid': 4520576}}
2024-07-17 10:32:21.682 DEBUG os_net_config.set_dcbx Got DCBX mode for enp4s0f1np1 mode:0
2024-07-17 10:32:21.682 DEBUG os_net_config.send_and_receive Sending message RTM_GETDCB cmd DCB_CMD_IEEE_GET attr []
2024-07-17 10:32:21.684 DEBUG os_net_config.send_and_receive Received message {'family': 0, 'cmd': 21, 'pad': 0, 'attrs': [('DCB_ATTR_IFNAME', 'enp4s0f1np1'), ('DCB_ATTR_IEEE', {'attrs': [('DCB_ATTR_IEEE_ETS', {'willing': 0, 'ets_cap': 8, 'cbs': 0, 'tc_tx_bw': (20, 20, 60, 100, 100, 100, 100, 100), 'tc_rx_bw': (0, 0, 0, 0, 0, 0, 0, 0), 'tc_tsa': (2, 2, 2, 255, 255, 255, 255, 255), 'prio_tc': (1, 2, 2, 0, 1, 2, 2, 0), 'tc_reco_bw': (0, 0, 0, 0, 0, 0, 0, 0), 'tc_reco_tsa': (0, 0, 0, 0, 0, 0, 0, 0), 'reco_prio_tc': (0, 0, 0, 0, 0, 0, 0, 0)}), ('UNKNOWN', {'header': {'length': 68, 'type': 7}}), ('DCB_ATTR_IEEE_PFC', {'pfc_cap': 8, 'pfc_en': 0, 'mbc': 0, 'delay': 1792, 'requests': (0, 0, 0, 0, 0, 0, 0, 0), 'indications': (0, 0, 0, 0, 0, 0, 0, 0)}), ('UNKNOWN', {'header': {'length': 48, 'type': 10}}), ('DCB_ATTR_IEEE_APP_TABLE', {'attrs': []})]}), ('DCB_ATTR_DCBX', 12)], 'header': {'length': 372, 'type': 78, 'flags': 1, 'sequence_number': 3, 'pid': 4520576}}
2024-07-17 10:32:21.685 DEBUG os_net_config.apply Adding DcbApp {Priority: 2 Protocol: 24 Selector: 5}
2024-07-17 10:32:21.685 DEBUG os_net_config.apply Adding DcbApp {Priority: 3 Protocol: 8 Selector: 5}
2024-07-17 10:32:21.685 DEBUG os_net_config.apply Adding DcbApp {Priority: 4 Protocol: 12 Selector: 5}
2024-07-17 10:32:21.685 DEBUG os_net_config.set_ieee_app Adding ieee app {'selector': 5, 'priority': 2, 'protocol': 24}
2024-07-17 10:32:21.686 DEBUG os_net_config.send_and_receive Sending message RTM_SETDCB cmd DCB_CMD_IEEE_SET attr [['DCB_ATTR_IEEE', {'attrs': [['DCB_ATTR_IEEE_APP_TABLE', {'attrs': [['DCB_ATTR_IEEE_APP', {'selector': 5, 'priority': 2, 'protocol': 24}]]}]]}]]
2024-07-17 10:32:21.688 DEBUG os_net_config.send_and_receive Received message {'family': 0, 'cmd': 20, 'pad': 0, 'attrs': [('DCB_ATTR_IEEE', {'attrs': []})], 'header': {'length': 28, 'type': 79, 'flags': 1, 'sequence_number': 4, 'pid': 4520576}}
2024-07-17 10:32:21.688 DEBUG os_net_config.set_ieee_app Adding ieee app {'selector': 5, 'priority': 3, 'protocol': 8}
2024-07-17 10:32:21.688 DEBUG os_net_config.send_and_receive Sending message RTM_SETDCB cmd DCB_CMD_IEEE_SET attr [['DCB_ATTR_IEEE', {'attrs': [['DCB_ATTR_IEEE_APP_TABLE', {'attrs': [['DCB_ATTR_IEEE_APP', {'selector': 5, 'priority': 3, 'protocol': 8}]]}]]}]]
2024-07-17 10:32:21.690 DEBUG os_net_config.send_and_receive Received message {'family': 0, 'cmd': 20, 'pad': 0, 'attrs': [('DCB_ATTR_IEEE', {'attrs': []})], 'header': {'length': 28, 'type': 79, 'flags': 1, 'sequence_number': 5, 'pid': 4520576}}
2024-07-17 10:32:21.690 DEBUG os_net_config.set_ieee_app Adding ieee app {'selector': 5, 'priority': 4, 'protocol': 12}
2024-07-17 10:32:21.690 DEBUG os_net_config.send_and_receive Sending message RTM_SETDCB cmd DCB_CMD_IEEE_SET attr [['DCB_ATTR_IEEE', {'attrs': [['DCB_ATTR_IEEE_APP_TABLE', {'attrs': [['DCB_ATTR_IEEE_APP', {'selector': 5, 'priority': 4, 'protocol': 12}]]}]]}]]
2024-07-17 10:32:21.692 DEBUG os_net_config.send_and_receive Received message {'family': 0, 'cmd': 20, 'pad': 0, 'attrs': [('DCB_ATTR_IEEE', {'attrs': []})], 'header': {'length': 28, 'type': 79, 'flags': 1, 'sequence_number': 6, 'pid': 4520576}}
[cloud-admin@rhos-nfv-10 ~]$ 
[cloud-admin@rhos-nfv-10 ~]$ 
[cloud-admin@rhos-nfv-10 ~]$ 
[cloud-admin@rhos-nfv-10 ~]$ 
[cloud-admin@rhos-nfv-10 ~]$ sudo os-net-config-dcb --show
2024-07-17 10:32:36.192 INFO os_net_config.show -----------------------------
2024-07-17 10:32:36.192 INFO os_net_config.show Interface: enp4s0f0np0
2024-07-17 10:32:36.193 INFO os_net_config.show DCBX Mode : FW Controlled
2024-07-17 10:32:36.193 INFO os_net_config.show Trust mode: dscp
2024-07-17 10:32:36.193 INFO os_net_config.show dscp2prio mapping: 	prio:2 dscp:24 	prio:3 dscp:08 	prio:4 dscp:12 
2024-07-17 10:32:36.193 INFO os_net_config.show tc: 0 , tsa: ets, bw: 20%, priority:  3  7 
2024-07-17 10:32:36.193 INFO os_net_config.show tc: 1 , tsa: ets, bw: 20%, priority:  0  4 
2024-07-17 10:32:36.193 INFO os_net_config.show tc: 2 , tsa: ets, bw: 60%, priority:  1  2  5  6 
2024-07-17 10:32:36.197 INFO os_net_config.show -----------------------------
2024-07-17 10:32:36.197 INFO os_net_config.show Interface: enp4s0f1np1
2024-07-17 10:32:36.198 INFO os_net_config.show DCBX Mode : FW Controlled
2024-07-17 10:32:36.198 INFO os_net_config.show Trust mode: dscp
2024-07-17 10:32:36.198 INFO os_net_config.show dscp2prio mapping: 	prio:2 dscp:24 	prio:3 dscp:08 	prio:4 dscp:12 
2024-07-17 10:32:36.198 INFO os_net_config.show tc: 0 , tsa: ets, bw: 20%, priority:  3  7 
2024-07-17 10:32:36.198 INFO os_net_config.show tc: 1 , tsa: ets, bw: 20%, priority:  0  4 
2024-07-17 10:32:36.198 INFO os_net_config.show tc: 2 , tsa: ets, bw: 60%, priority:  1  2  5  6 
[cloud-admin@rhos-nfv-10 ~]$ 
[cloud-admin@rhos-nfv-10 ~]$ 
[cloud-admin@rhos-nfv-10 ~]$ cat /var/lib/os-net-config/dcb_config.yaml 
- driver: mlx5_core
  dscp2prio:
  - priority: 2
    protocol: 24
    selector: 5
  - priority: 3
    protocol: 8
    selector: 5
  - priority: 4
    protocol: 12
    selector: 5
  name: enp4s0f0np0
  pci_addr: '0000:04:00.0'
- driver: mlx5_core
  dscp2prio:
  - priority: 2
    protocol: 24
    selector: 5
  - priority: 3
    protocol: 8
    selector: 5
  - priority: 4
    protocol: 12
    selector: 5
  name: enp4s0f1np1
  pci_addr: '0000:04:00.1'
[cloud-admin@rhos-nfv-10 ~]$ 
[cloud-admin@rhos-nfv-10 ~]$ sudo cat /etc/os-net-config/config.yaml
---
network_config:
- type: linux_bond
  name: bond_api
  use_dhcp: false
  bonding_options: "mode=active-backup"
  dns_servers: ['192.168.122.80']
  addresses:
  - ip_netmask: 192.168.122.101/24
  routes:
  - default: true
    next_hop: 192.168.122.1
  members:
  - type: interface
    name: nic2
    primary: true
- type: vlan
  vlan_id: 202
  device: bond_api
  addresses:
  - ip_netmask: 172.17.0.100/24
  routes: []
- type: vlan
  vlan_id: 203
  device: bond_api
  addresses:
  - ip_netmask: 172.18.0.100/24
  routes: []
- type: ovs_user_bridge
  name: br-link1
  use_dhcp: false
  mtu: 9000
  members:
  - type: ovs_dpdk_port
    name: dpdk1
    driver: mlx5_core
    mtu: 9000
    members:
    - type: interface
      name: nic3
      dcb:
          dscp2prio:
              - priority: 2
                protocol: 24
              - priority: 3
                protocol: 8
              - priority: 4
                protocol: 12
- type: ovs_user_bridge
  name: br-link2
  use_dhcp: false
  mtu: 9000
  members:
  - type: ovs_dpdk_port
    name: dpdk2
    driver: mlx5_core
    members:
    - type: interface
      name: nic4
      dcb:
          dscp2prio:
              - priority: 2
                protocol: 24
              - priority: 3
                protocol: 8
              - priority: 4
                protocol: 12
- type: interface
  name: nic5
  use_dhcp: false
  use_dhcpv6: false
- type: interface
  name: nic6
  use_dhcp: false
  use_dhcpv6: false
- type: interface
  name: nic1
  use_dhcp: true
  use_dhcpv6: false
[cloud-admin@rhos-nfv-10 ~]$ 
