### PR TITLE
sriov_config: fix race condition on boot

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -28,6 +28,7 @@ from os_net_config import impl_ifcfg
 from os_net_config import impl_iproute
 from os_net_config import impl_nmstate
 from os_net_config import objects
+from os_net_config import sriov_config
 from os_net_config import utils
 from os_net_config import validator
 from os_net_config import version
@@ -329,7 +330,7 @@ def main(argv=sys.argv, main_logger=None):
             restart_ovs = bool(sriovpf_bond_ovs_ports)
             # Avoid ovs restart for os-net-config re-runs, which will
             # dirupt the offload configuration
-            if os.path.exists(utils._SRIOV_CONFIG_SERVICE_FILE):
+            if os.path.exists(sriov_config._UDEV_LEGACY_RULE_FILE):
                 restart_ovs = False
 
             utils.configure_sriov_pfs(


### PR DESCRIPTION
On boot, sriov_config.service runs in parallel with the probing of PCI devices. There is no synchronisation point that we can use to run the service *after* all PCI devices have been probed. This leads to the service failing depending on the time it takes for devices to be probed:

```
 12:31:30 os-net-config-sriov[1772]: FileNotFoundError: [Errno 2] No
  such file or directory: '/sys/class/net/ens2f0np0/device/sriov_numvfs'
 ...
 12:31:43 kernel: mlx5_core 0000:17:00.0 ens2f0np0: renamed from eth0
```

Remove that service an only rely on UDEV rules to configure the correct amount of VFs when the PF device appears.