### PR TITLE
sriov_config: fix race condition on boot

### DIFF
--- a/os_net_config/sriov_config.py
+++ b/os_net_config/sriov_config.py
@@ -170,6 +170,9 @@ def get_numvfs(ifname):
     :returns: int -- the number of current VFs on ifname
     :raises: SRIOVNumvfsException
     """
+    cmd = ["/usr/bin/udevadm", "wait", common.get_dev_path(ifname)]
+    logger.debug(f"{ifname}: Running command: {cmd}")
+    processutils.execute(*cmd)
     sriov_numvfs_path = common.get_dev_path(ifname, "sriov_numvfs")
     logger.debug(f"{ifname}: Getting numvfs for interface")
     try:

--- a/os_net_config/tests/test_sriov_config.py
+++ b/os_net_config/tests/test_sriov_config.py
@@ -33,8 +33,12 @@ class TestSriovConfig(base.TestCase):
         super(TestSriovConfig, self).setUp()
         rand = str(int(random.random() * 100000))
 
+        def execute_noop(*args, **kw):
+            pass
+
         tmpdir = tempfile.mkdtemp()
         self.stub_out('os_net_config.common.SYS_CLASS_NET', tmpdir)
+        self.stub_out('oslo_concurrency.processutils.execute', execute_noop)
 
         common._LOG_FILE = '/tmp/' + rand + 'os_net_config.log'
         sriov_config._UDEV_RULE_FILE = '/tmp/' + rand + 'etc_udev_rules.d'\


### PR DESCRIPTION
On boot, sriov_config.service runs in parallel with the probing of PCI devices. There is no synchronization point that we can use to run the service *after* all PCI devices have been probed. This leads to the service failing depending on the time it takes for devices to be probed:

```
12:31:30 os-net-config-sriov[1772]: FileNotFoundError: [Errno 2] No such file or directory: '/sys/class/net/ens2f0np0/device/sriov_numvfs'
...
12:31:43 kernel: mlx5_core 0000:17:00.0 ens2f0np0: renamed from eth0
```

The issue is that there is no UDEV rule to back this up when using NIC partitioning.
    
Add an explicit call to udevadm wait before trying to access the files. If the devices have already been probed, it will not cause any delay. On the other hand, if the devices haven't been probed yet or if the configuration is incorrect, the command will timeout after 120 seconds and raise an error.
    
Closes: https://issues.redhat.com/browse/OSPRH-8922