### PR TITLE
sriov_config: give up on waiting for pf after 60 seconds

### DIFF
--- a/os_net_config/sriov_config.py
+++ b/os_net_config/sriov_config.py
@@ -170,7 +170,7 @@ def get_numvfs(ifname):
     :returns: int -- the number of current VFs on ifname
     :raises: SRIOVNumvfsException
     """
-    cmd = ["/usr/bin/udevadm", "wait", common.get_dev_path(ifname)]
+    cmd = ["/usr/bin/udevadm", "wait", "-t", "60", common.get_dev_path(ifname)]
     logger.debug(f"{ifname}: Running command: {cmd}")
     processutils.execute(*cmd)
     sriov_numvfs_path = common.get_dev_path(ifname, "sriov_numvfs")


### PR DESCRIPTION
By default, udevadm wait has no timeout. If the `-t`, `--timeout` option is not specified, the command will wait for the device to be initialized forever. Here's an excerpt from `udevadm(8)`:

```
 udevadm wait [options] [device|syspath] ...
     Wait for devices or device symlinks being created and initialized
     by systemd-udevd.

     -t, --timeout=SECONDS
         Maximum number of seconds to wait for the specified devices or
         device symlinks being created, initialized, or removed. The
         default value is "infinity".
                           ^^^^^^^^
```

If there is a misconfiguration or a hardware issue, this can lead to stalling on boot.

Add an explicit 60 seconds timeout after which the command will fail with an explicit error:

```
  Timed out for waiting devices being initialized.
```