### PR TITLE
Adding pep8 and  py39 jobs back to CI

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -14,6 +14,10 @@
       jobs:
         - tox-linters:
             nodeset: rdo-centos-9-stream
+        - tox-py39:
+            nodeset: rdo-centos-9-stream
+        - tox-pep8:
+            nodeset: rdo-centos-9-stream
         - openstack-services-content-provider:
             files: &_files
               - ^os_net_config/*


### PR DESCRIPTION
The py39 and pep8 jobs were previously removed due to limited CI resources and now adding them back to ensure compliance in validation.