### PR TITLE
Update the VF args for OvS / OvS user bridges for nmstate provider

### DIFF
--- a/os_net_config/tests/test_impl_nmstate.py
+++ b/os_net_config/tests/test_impl_nmstate.py
@@ -1396,9 +1396,10 @@ class TestNmstateNetConfig(base.TestCase):
         """
 
         ovs_obj = objects.object_from_json(yaml.safe_load(ovs_config))
+        bond_vf = ovs_obj.members[0]
+        for vf in bond_vf.members:
+            self.provider.add_sriov_vf(vf)
         self.provider.add_bridge(ovs_obj)
-        self.provider.add_sriov_vf(ovs_obj.members[0].members[0])
-        self.provider.add_sriov_vf(ovs_obj.members[0].members[1])
 
         exp_pf_config = """
         - name: eth2
@@ -1479,6 +1480,394 @@ class TestNmstateNetConfig(base.TestCase):
         self.assertEqual(yaml.safe_load(exp_bridge_config),
                          self.get_bridge_config('br-bond'))
 
+    def test_sriov_pf_with_nicpart_ovs_user_bridge_no_bond(self):
+        nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1', 'nic3': 'eth2'}
+        self.stubbed_mapped_nics = nic_mapping
+
+        def update_sriov_pf_map_stub(ifname, numvfs, noop, promisc=None,
+                                     link_mode='legacy', vdpa=False,
+                                     steering_mode=None, lag_candidate=None):
+            return
+        self.stub_out('os_net_config.utils.update_sriov_pf_map',
+                      update_sriov_pf_map_stub)
+
+        def test_get_vf_devname(device, vfid):
+            return device + '_' + str(vfid)
+        self.stub_out('os_net_config.utils.get_vf_devname',
+                      test_get_vf_devname)
+
+        pf2 = objects.SriovPF(name='nic2', numvfs=10)
+        self.provider.add_sriov_pf(pf2)
+
+        ovs_config = """
+        type: ovs_user_bridge
+        name: br-dpdk2
+        members:
+          -
+            type: ovs_dpdk_port
+            name: dpdk2
+            members:
+              -
+                type: sriov_vf
+                device: nic2
+                vfid: 2
+                vlan_id: 112
+                qos: 4
+        """
+
+        def test_bind_dpdk_interfaces(ifname, driver, noop):
+            return
+        self.stub_out('os_net_config.utils.bind_dpdk_interfaces',
+                      test_bind_dpdk_interfaces)
+        ovs_obj = objects.object_from_json(yaml.safe_load(ovs_config))
+        self.provider.add_sriov_vf(ovs_obj.members[0].members[0])
+        self.provider.add_ovs_dpdk_port(ovs_obj.members[0])
+        self.provider.add_ovs_user_bridge(ovs_obj)
+
+        exp_pf_config = """
+        - name: eth1
+          state: up
+          type: ethernet
+          ethernet:
+              sr-iov:
+                  total-vfs: 10
+                  vfs:
+                  - id: 2
+                    spoof-check: false
+                    trust: true
+                    vlan-id: 112
+                    qos: 4
+          ethtool:
+             feature:
+                hw-tc-offload: False
+          ipv4:
+              dhcp: False
+              enabled: False
+          ipv6:
+              autoconf: False
+              dhcp: False
+              enabled: False
+        """
+
+        exp_bridge_config = """
+        name: br-dpdk2
+        state: up
+        type: ovs-bridge
+        bridge:
+            options:
+                datapath: netdev
+                fail-mode: standalone
+                mcast-snooping-enable: False
+                rstp: False
+                stp: False
+            port:
+                - name: dpdk2
+                - name: br-dpdk2-p
+        ovs-db:
+            external_ids: {}
+            other_config: {'mac-table-size': 50000}
+        """
+
+        vf_config = self.provider.prepare_sriov_vf_config()
+        self.assertEqual(yaml.safe_load(exp_pf_config),
+                         vf_config)
+        self.assertEqual(yaml.safe_load(exp_bridge_config),
+                         self.get_bridge_config('br-dpdk2'))
+
+    def test_sriov_pf_with_nicpart_ovs_user_bridge(self):
+        nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1', 'nic3': 'eth2'}
+        self.stubbed_mapped_nics = nic_mapping
+
+        def update_sriov_pf_map_stub(ifname, numvfs, noop, promisc=None,
+                                     link_mode='legacy', vdpa=False,
+                                     steering_mode=None, lag_candidate=None):
+            return
+        self.stub_out('os_net_config.utils.update_sriov_pf_map',
+                      update_sriov_pf_map_stub)
+
+        def test_get_vf_devname(device, vfid):
+            return device + '_' + str(vfid)
+        self.stub_out('os_net_config.utils.get_vf_devname',
+                      test_get_vf_devname)
+
+        pf1 = objects.SriovPF(name='nic3', numvfs=10)
+        self.provider.add_sriov_pf(pf1)
+        pf2 = objects.SriovPF(name='nic2', numvfs=10)
+        self.provider.add_sriov_pf(pf2)
+
+        ovs_config = """
+        type: ovs_user_bridge
+        name: br-bond
+        members:
+          -
+            type: ovs_dpdk_bond
+            name: dpdkbond1
+            ovs_options: "bond_mode=active-backup"
+            members:
+              -
+                type: ovs_dpdk_port
+                name: dpdk2
+                members:
+                  -
+                    type: sriov_vf
+                    device: nic2
+                    vfid: 2
+                    vlan_id: 112
+                    qos: 4
+                    primary: true
+              -
+                type: ovs_dpdk_port
+                name: dpdk3
+                members:
+                  -
+                    type: sriov_vf
+                    device: nic3
+                    vfid: 2
+                    vlan_id: 112
+                    qos: 4
+        """
+
+        def test_bind_dpdk_interfaces(ifname, driver, noop):
+            return
+        self.stub_out('os_net_config.utils.bind_dpdk_interfaces',
+                      test_bind_dpdk_interfaces)
+        ovs_obj = objects.object_from_json(yaml.safe_load(ovs_config))
+        dpdk_bond = ovs_obj.members[0]
+        for dpdk_port in dpdk_bond.members:
+            vf = dpdk_port.members[0]
+            self.provider.add_sriov_vf(vf)
+            self.provider.add_ovs_dpdk_port(dpdk_port)
+        self.provider.add_ovs_user_bridge(ovs_obj)
+
+        exp_pf_config = """
+        - name: eth2
+          state: up
+          type: ethernet
+          ethernet:
+              sr-iov:
+                  total-vfs: 10
+                  vfs:
+                  - id: 2
+                    spoof-check: false
+                    trust: true
+                    vlan-id: 112
+                    qos: 4
+          ethtool:
+             feature:
+                hw-tc-offload: False
+          ipv4:
+              dhcp: False
+              enabled: False
+          ipv6:
+              autoconf: False
+              dhcp: False
+              enabled: False
+        - name: eth1
+          state: up
+          type: ethernet
+          ethernet:
+              sr-iov:
+                  total-vfs: 10
+                  vfs:
+                  - id: 2
+                    spoof-check: false
+                    trust: true
+                    vlan-id: 112
+                    qos: 4
+          ethtool:
+             feature:
+                hw-tc-offload: False
+          ipv4:
+              dhcp: False
+              enabled: False
+          ipv6:
+              autoconf: False
+              dhcp: False
+              enabled: False
+        """
+
+        exp_bridge_config = """
+        name: br-bond
+        state: up
+        type: ovs-bridge
+        bridge:
+            options:
+                datapath: netdev
+                fail-mode: standalone
+                mcast-snooping-enable: False
+                rstp: False
+                stp: False
+            port:
+                - name: dpdkbond1
+                  link-aggregation:
+                      mode: active-backup
+                      ovs-db:
+                          other_config:
+                              bond-primary: dpdk2
+                      port:
+                          - name: dpdk2
+                          - name: dpdk3
+                - name: br-bond-p
+        ovs-db:
+            external_ids: {}
+            other_config: {'mac-table-size': 50000}
+        """
+
+        vf_config = self.provider.prepare_sriov_vf_config()
+        self.assertEqual(yaml.safe_load(exp_pf_config),
+                         vf_config)
+        self.assertEqual(yaml.safe_load(exp_bridge_config),
+                         self.get_bridge_config('br-bond'))
+
+    def test_sriov_pf_with_custom_nicpart_ovs_user_bridge(self):
+        nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1', 'nic3': 'eth2'}
+        self.stubbed_mapped_nics = nic_mapping
+
+        def update_sriov_pf_map_stub(ifname, numvfs, noop, promisc=None,
+                                     link_mode='legacy', vdpa=False,
+                                     steering_mode=None, lag_candidate=None):
+            return
+        self.stub_out('os_net_config.utils.update_sriov_pf_map',
+                      update_sriov_pf_map_stub)
+
+        def test_get_vf_devname(device, vfid):
+            return device + '_' + str(vfid)
+        self.stub_out('os_net_config.utils.get_vf_devname',
+                      test_get_vf_devname)
+
+        pf1 = objects.SriovPF(name='nic3', numvfs=10)
+        self.provider.add_sriov_pf(pf1)
+        pf2 = objects.SriovPF(name='nic2', numvfs=10)
+        self.provider.add_sriov_pf(pf2)
+
+        ovs_config = """
+        type: ovs_user_bridge
+        name: br-bond
+        members:
+          -
+            type: ovs_dpdk_bond
+            name: dpdkbond1
+            ovs_options: "bond_mode=active-backup"
+            members:
+              -
+                type: ovs_dpdk_port
+                name: dpdk2
+                members:
+                  -
+                    type: sriov_vf
+                    device: nic2
+                    vfid: 2
+                    vlan_id: 112
+                    qos: 4
+                    trust: off
+                    spoofcheck: on
+                    primary: true
+              -
+                type: ovs_dpdk_port
+                name: dpdk3
+                members:
+                  -
+                    type: sriov_vf
+                    device: nic3
+                    vfid: 2
+                    vlan_id: 112
+                    qos: 4
+                    trust: off
+                    spoofcheck: on
+        """
+
+        def test_bind_dpdk_interfaces(ifname, driver, noop):
+            return
+        self.stub_out('os_net_config.utils.bind_dpdk_interfaces',
+                      test_bind_dpdk_interfaces)
+        ovs_obj = objects.object_from_json(yaml.safe_load(ovs_config))
+        dpdk_bond = ovs_obj.members[0]
+        for dpdk_port in dpdk_bond.members:
+            vf = dpdk_port.members[0]
+            self.provider.add_sriov_vf(vf)
+            self.provider.add_ovs_dpdk_port(dpdk_port)
+        self.provider.add_ovs_user_bridge(ovs_obj)
+
+        exp_pf_config = """
+        - name: eth2
+          state: up
+          type: ethernet
+          ethernet:
+              sr-iov:
+                  total-vfs: 10
+                  vfs:
+                  - id: 2
+                    spoof-check: true
+                    trust: false
+                    vlan-id: 112
+                    qos: 4
+          ethtool:
+             feature:
+                hw-tc-offload: False
+          ipv4:
+              dhcp: False
+              enabled: False
+          ipv6:
+              autoconf: False
+              dhcp: False
+              enabled: False
+        - name: eth1
+          state: up
+          type: ethernet
+          ethernet:
+              sr-iov:
+                  total-vfs: 10
+                  vfs:
+                  - id: 2
+                    spoof-check: true
+                    trust: false
+                    vlan-id: 112
+                    qos: 4
+          ethtool:
+             feature:
+                hw-tc-offload: False
+          ipv4:
+              dhcp: False
+              enabled: False
+          ipv6:
+              autoconf: False
+              dhcp: False
+              enabled: False
+        """
+
+        exp_bridge_config = """
+        name: br-bond
+        state: up
+        type: ovs-bridge
+        bridge:
+            options:
+                datapath: netdev
+                fail-mode: standalone
+                mcast-snooping-enable: False
+                rstp: False
+                stp: False
+            port:
+                - name: dpdkbond1
+                  link-aggregation:
+                      mode: active-backup
+                      ovs-db:
+                          other_config:
+                              bond-primary: dpdk2
+                      port:
+                          - name: dpdk2
+                          - name: dpdk3
+                - name: br-bond-p
+        ovs-db:
+            external_ids: {}
+            other_config: {'mac-table-size': 50000}
+        """
+
+        vf_config = self.provider.prepare_sriov_vf_config()
+        self.assertEqual(yaml.safe_load(exp_pf_config),
+                         vf_config)
+        self.assertEqual(yaml.safe_load(exp_bridge_config),
+                         self.get_bridge_config('br-bond'))
+
     def test_sriov_pf_with_nicpart_linux_bond(self):
         nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1', 'nic3': 'eth2'}
         self.stubbed_mapped_nics = nic_mapping
@@ -1522,9 +1911,9 @@ class TestNmstateNetConfig(base.TestCase):
         """
 
         lb_obj = objects.object_from_json(yaml.safe_load(lnxbond_config))
+        for vf_obj in lb_obj.members:
+            self.provider.add_sriov_vf(vf_obj)
         self.provider.add_linux_bond(lb_obj)
-        self.provider.add_sriov_vf(lb_obj.members[0])
-        self.provider.add_sriov_vf(lb_obj.members[1])
 
         exp_pf_config = """
         - name: eth2


### PR DESCRIPTION
The default values of the VF parameters like Trust, Spoofcheck, Promisc are updated for OvS and OvS user bridges, Linux bonds. This update is not effectively applied on the nmstate provider's sriov_vf_data, leading to inconsistency between the sriov map and the VF configurations applied. Now the update of the default values are applied on sriov_vf_data.

Depends-On: https://github.com/os-net-config/os-net-config/pull/40