### PR TITLE
Add override-checkout main to the content provider job

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -15,6 +15,7 @@
         - tox-linters:
             nodeset: rdo-centos-9-stream
         - openstack-services-content-provider:
+            override-checkout: main
             files: &_files
               - ^os_net_config/*
         - podified-multinode-edpm-deployment-crc:


### PR DESCRIPTION
https://review.rdoproject.org/r/c/config/+/53945 limit the job inclusion from ci-framework main and proposed-18 branch.
  
openstack-services-content-provider's parent *cifmw-tcib-base* defined in ci-framework. ci-framework repo has main branch. os-net-config has master branch. The zuul is not able run the job *openstack-services-content-provider* due to branch difference and giving following error:
```
Unable to freeze job graph: Job podified-multinode-edpm-deployment-crc depends on openstack-services-content-provider which was not run.
``` 
Setting override-checkout to main and tells the zuul to use proper branch and run the job. Hence, it  fixes the issue.
    
    Signed-off-by: Chandan Kumar <raukadah@gmail.com>
