### PR TITLE
Exception logging shall also be stored in default log file

### DIFF
--- a/os_net_config/__init__.py
+++ b/os_net_config/__init__.py
@@ -315,7 +315,11 @@ class NetConfig(object):
         """
         logger.info('%s%s' % (self.log_prefix, msg))
         if not self.noop:
-            processutils.execute(cmd, *args, **kwargs)
+            out, err = processutils.execute(cmd, *args, **kwargs)
+            if err:
+                logger.error(f"stderr : {err}")
+            if out:
+                logger.debug(f"stdout : {out}")
 
     def write_config(self, filename, data, msg=None):
         msg = msg or "Writing config %s" % filename

--- a/os_net_config/common.py
+++ b/os_net_config/common.py
@@ -24,6 +24,7 @@ import logging.handlers
 import os
 from oslo_concurrency import processutils
 import sys
+import traceback
 import yaml
 
 # File to contain the DPDK mapped nics, as nic name will not be available after
@@ -82,6 +83,13 @@ class OvsDpdkBindException(ValueError):
     pass
 
 
+def log_exceptions(type, value, tb):
+    logger.exception(''.join(traceback.format_exception(
+        type, value, tb)))
+    # calls default excepthook
+    sys.__excepthook__(type, value, tb)
+
+
 def configure_logger(log_file=False, verbose=False, debug=False):
     LOG_FORMAT = ('%(asctime)s.%(msecs)03d %(levelname)s '
                   '%(name)s.%(funcName)s %(message)s')
@@ -100,6 +108,8 @@ def configure_logger(log_file=False, verbose=False, debug=False):
     stream_handler = logging.StreamHandler(sys.stdout)
     stream_handler.setFormatter(formatter)
     logger.addHandler(stream_handler)
+    # Install exception handler
+    sys.excepthook = log_exceptions
     return logger
 
 

--- a/os_net_config/dcb_config.py
+++ b/os_net_config/dcb_config.py
@@ -15,6 +15,7 @@
 # under the License.
 
 import argparse
+import logging
 import os
 import sys
 import yaml
@@ -42,7 +43,7 @@ IEEE_8021QAZ_TSA_STRICT = 0
 IEEE_8021QAZ_TSA_ETS = 2
 IEEE_8021QAZ_TSA_VENDOR = 255
 
-logger = common.configure_logger()
+logger = logging.getLogger(__name__)
 
 
 class DCBErrorException(ValueError):
@@ -511,7 +512,7 @@ def parse_config(user_config_file):
 
 def main(argv=sys.argv):
     opts = parse_opts(argv)
-    common.configure_logger(log_file=True)
+    logger = common.configure_logger(log_file=True)
     common.logger_level(logger, opts.verbose, opts.debug)
 
     if opts.config_file:

--- a/os_net_config/sriov_config.py
+++ b/os_net_config/sriov_config.py
@@ -22,6 +22,7 @@
 # An entry point os-net-config-sriov is added for invocation of this module.
 
 import argparse
+import logging
 import os
 import pyudev
 import queue
@@ -34,7 +35,7 @@ from os_net_config import common
 from os_net_config import sriov_bind_config
 from oslo_concurrency import processutils
 
-logger = common.configure_logger()
+logger = logging.getLogger(__name__)
 
 _UDEV_RULE_FILE = '/etc/udev/rules.d/80-persistent-os-net-config.rules'
 _UDEV_LEGACY_RULE_FILE = '/etc/udev/rules.d/70-os-net-config-sriov.rules'
@@ -821,18 +822,17 @@ def parse_opts(argv):
     return opts
 
 
-def main(argv=sys.argv, main_logger=None):
+def main(argv=sys.argv):
     opts = parse_opts(argv)
-    if not main_logger:
-        main_logger = common.configure_logger(log_file=True)
-    common.logger_level(main_logger, opts.verbose, opts.debug)
+    logger = common.configure_logger(log_file=True)
+    common.logger_level(logger, opts.verbose, opts.debug)
 
     if opts.numvfs:
         if re.match(r"^\w+:\d+$", opts.numvfs):
             device_name, numvfs = opts.numvfs.split(':')
             set_numvfs(device_name, int(numvfs))
         else:
-            main_logger.error(f"Invalid arguments for --numvfs {opts.numvfs}")
+            logger.error(f"Invalid arguments for --numvfs {opts.numvfs}")
             return 1
     else:
         # Configure the PF's

--- a/os_net_config/tests/test_impl_eni.py
+++ b/os_net_config/tests/test_impl_eni.py
@@ -325,6 +325,7 @@ class TestENINetConfigApply(base.TestCase):
             if args[0] == '/sbin/ifup':
                 self.ifup_interface_names.append(args[1])
             pass
+            return ('stdout', 'stderr')
 
         self.stub_out('oslo_concurrency.processutils.execute', test_execute)
 
@@ -379,6 +380,7 @@ class TestENINetConfigApply(base.TestCase):
             raise processutils.ProcessExecutionError('Test stderr',
                                                      'Test stdout',
                                                      str(kwargs))
+        return ('stdout', 'stderr')
 
     def test_interface_failure(self):
         self.stub_out('oslo_concurrency.processutils.execute',

--- a/os_net_config/tests/test_impl_ifcfg.py
+++ b/os_net_config/tests/test_impl_ifcfg.py
@@ -2297,6 +2297,7 @@ class TestIfcfgNetConfigApply(base.TestCase):
             elif args[0] == '/sbin/ip' or args[0] == '/usr/sbin/ip':
                 self.ip_reconfigure_commands.append(' '.join(args[1:]))
             pass
+            return ('stdout', 'stderr')
         self.stub_out('oslo_concurrency.processutils.execute', test_execute)
 
         def stub_is_ovs_installed():
@@ -2846,6 +2847,7 @@ class TestIfcfgNetConfigApply(base.TestCase):
             raise processutils.ProcessExecutionError('Test stderr',
                                                      'Test stdout',
                                                      str(kwargs))
+        return ('stdout', 'stderr')
 
     def test_interface_failure(self):
         self.stub_out('oslo_concurrency.processutils.execute',


### PR DESCRIPTION
Allow `os-net-config-sriov` and `os-net-config-dcb` logs to be stored in the default log file. Also the exception logs shall be stored in the default log file.

Depends-On: https://github.com/os-net-config/os-net-config/pull/46