### PR TITLE
Update schema for dpdkbond members

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -73,7 +73,7 @@ def parse_opts(argv):
         action='store_true',
         help="Exit with an error if configuration file validation fails. "
              "Without this option, just log a warning and continue.",
-        default=False)
+        default=True)
 
     parser.add_argument(
         '-d', '--debug',

--- a/os_net_config/schema.yaml
+++ b/os_net_config/schema.yaml
@@ -850,6 +850,7 @@ definitions:
                 type: array
                 items:
                   - $ref: "#/definitions/ovs_dpdk_port"
+                minItems: 2
             ovs_options:
                 $ref: "#/definitions/ovs_options_string_or_param"
             ovs_extra:

--- a/os_net_config/tests/test_validator.py
+++ b/os_net_config/tests/test_validator.py
@@ -442,6 +442,62 @@ class TestDeviceTypes(base.TestCase):
         }
         self.assertTrue(v.is_valid(data))
 
+    def test_ovs_user_bridge_members(self):
+        schema = validator.get_schema_for_defined_type("ovs_user_bridge")
+        v = jsonschema.Draft4Validator(schema)
+        data1 = {
+            "type": "ovs_user_bridge",
+            "name": "br-link0",
+            "members": [{
+                "type": "ovs_dpdk_bond",
+                "name": "dpdkbond0",
+                "mtu": 9000,
+                "rx_queue": 2,
+                "members": [{
+                    "type": "ovs_dpdk_port",
+                    "name": "dpdk0",
+                    "members": [{
+                        "type": "interface",
+                        "name": "nic2"
+                    }]
+                }]
+            }]
+        }
+        data2 = {
+            "type": "ovs_user_bridge",
+            "name": "br-link1",
+            "members": [{
+                "type": "ovs_dpdk_bond",
+                "name": "dpdkbond1",
+                "mtu": 9000,
+                "rx_queue": 1,
+                "members": [{
+                    "type": "ovs_dpdk_port",
+                    "name": "dpdk0",
+                    "members": [{
+                        "type": "interface",
+                        "name": "nic2"
+                    }]
+                }, {
+                    "type": "ovs_dpdk_port",
+                    "name": "dpdk1",
+                    "members": [{
+                        "type": "interface",
+                        "name": "nic3"
+                    }]
+                }, {
+                    "type": "ovs_dpdk_port",
+                    "name": "dpdk2",
+                    "members": [{
+                        "type": "interface",
+                        "name": "nic4"
+                    }]
+                }]
+            }]
+        }
+        self.assertFalse(v.is_valid(data1))
+        self.assertTrue(v.is_valid(data2))
+
 
 class TestSampleFiles(base.TestCase):
 


### PR DESCRIPTION
Since there is a limitation from OvS for minimum 2 members required for dpdkbond members, updating
the schema to allow only 2 ports.
Set default failure for schema errors.
Added negative test cases for the same.