### PR TITLE
Roll back to previous provider incase of migration failure

### DIFF
--- a/os_net_config/__init__.py
+++ b/os_net_config/__init__.py
@@ -99,6 +99,10 @@ class NetConfig(object):
         logger.info('Migration is not supported for this provider')
         return
 
+    def roll_back_migration(self):
+        logger.info('roll back migration is not supported for this provider')
+        return
+
     def clean_migration(self):
         logger.info('clean migration is not supported for this provider')
         return

--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -1838,4 +1838,6 @@ class NmstateNetConfig(os_net_config.NetConfig):
         self.linuxbond_data = {}
         self.vlan_data = {}
 
+        logger.info('Succesfully applied the network configuration with '
+                    'nmstate provider')
         return updated_interfaces


### PR DESCRIPTION
In cases where migration of provider fails, the network configurations shall be rolled back to the previous provider.

Depends-On: https://github.com/os-net-config/os-net-config/pull/54