### PR TITLE
Add Multi-Queue support for vDPA devices (#7)

### DIFF
--- a/etc/os-net-config/samples/vdpa.json
+++ b/etc/os-net-config/samples/vdpa.json
@@ -9,6 +9,7 @@
                     "name": "p2p1",
                     "numvfs": 10,
                     "vdpa": true,
+                    "vdpa_queues": 50,
                     "use_dhcp": false,
                     "link_mode": "switchdev"
                 },
@@ -16,6 +17,7 @@
                     "type": "sriov_pf",
                     "name": "p2p2",
                     "numvfs": 10,
+                    "vdpa_queues": 50,
                     "vdpa": true,
                     "use_dhcp": false,
                     "link_mode": "switchdev"

--- a/etc/os-net-config/samples/vdpa.yaml
+++ b/etc/os-net-config/samples/vdpa.yaml
@@ -15,6 +15,8 @@ network_config:
       name: p2p1
       # Flag this PF as a vDPA device
       vdpa: true
+      # multi queue size for vDPA device
+      vdpa_queues: 50
       # number of VFs required on the particular NIC
       # Should be at least one when vdpa is true
       numvfs: 10
@@ -27,5 +29,6 @@ network_config:
       name: p2p2
       vdpa: true
       numvfs: 10
+      vdpa_queues: 50
       use_dhcp: false
       link_mode: switchdev

--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -1669,6 +1669,10 @@ class SriovPF(_BaseOpts):
         link_mode = json.get('link_mode', 'legacy')
         ethtool_opts = json.get('ethtool_opts', None)
         vdpa = json.get('vdpa', False)
+        vdpa_queues = json.get('vdpa_queues', None)
+        if vdpa_queues and not strutils.is_int_like(vdpa_queues):
+            msg = 'vdpa_queues config value must be an integer'
+            raise InvalidConfigException(msg)
         steering_mode = json.get('steering_mode')
         if steering_mode is not None and steering_mode not in ['smfs', 'dmfs']:
             msg = 'Expecting steering_mode to match smfs/dmfs'

--- a/os_net_config/schema.yaml
+++ b/os_net_config/schema.yaml
@@ -436,6 +436,8 @@ definitions:
                 $ref: "#/definitions/sriov_link_mode_or_param"
             vdpa:
                 $ref: "#/definitions/bool_or_param"
+            vdpa_queues:
+                $ref: "#/definitions/int_or_param"
             steering_mode:
                 $ref: "#/definitions/sriov_steering_mode_or_param"
             dcb:

--- a/os_net_config/sriov_config.py
+++ b/os_net_config/sriov_config.py
@@ -350,7 +350,8 @@ def configure_sriov_pf(execution_from_cli=False, restart_openvswitch=False):
                         _driver_unbind(vf_pci)
                     else:
                         if vf_pci not in vdpa_devices:
-                            configure_vdpa_vhost_device(vf_pci)
+                            vdpa_queues = item.get('vdpa_queues')
+                            configure_vdpa_vhost_device(vf_pci, vdpa_queues)
                         else:
                             logger.info(
                                 f"{item['name']}: vDPA device already created "
@@ -637,11 +638,22 @@ def get_vdpa_vhost_devices():
     return loads(stdout)['dev']
 
 
-def configure_vdpa_vhost_device(pci):
+def _configure_vdpa_queues(pci, vdpa_queues):
+    processutils.execute('devlink', 'dev', 'param', 'set', pci,
+                         'name', 'enable_eth', 'value', 'false',
+                         'cmode', 'driverinit')
+    processutils.execute('devlink', 'dev', 'reload', pci)
+
+
+def configure_vdpa_vhost_device(pci, vdpa_queues=None):
     logger.info(f"{pci}: Creating vdpa device")
     try:
-        processutils.execute('vdpa', 'dev', 'add', 'name', pci,
-                             'mgmtdev', f'pci/{pci}')
+        pci_path = f'pci/{pci}'
+        _configure_vdpa_queues(pci_path, vdpa_queues)
+        cmd = ['vdpa', 'dev', 'add', 'name', pci, 'mgmtdev', pci_path]
+        if vdpa_queues:
+            cmd.extend(['max_vqp', vdpa_queues])
+        processutils.execute(*cmd)
     except processutils.ProcessExecutionError as exc:
         logger.error(f"{pci}: Failed to create vdpa vhost device: {exc}")
         raise

--- a/os_net_config/tests/test_impl_ifcfg.py
+++ b/os_net_config/tests/test_impl_ifcfg.py
@@ -702,6 +702,13 @@ class TestIfcfgNetConfig(base.TestCase):
         self.stub_out('os_net_config.utils.update_sriov_pf_map',
                       test_update_sriov_pf_map)
 
+        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
+                                     link_mode='legacy', vdpa=False,
+                                     steering_mode="smfs"):
+            return
+        self.stub_out('os_net_config.utils.update_sriov_pf_map',
+                      test_update_sriov_pf_map)
+
     def tearDown(self):
         super(TestIfcfgNetConfig, self).tearDown()
         if os.path.isfile(common.SRIOV_CONFIG_FILE):
@@ -1373,12 +1380,6 @@ DHCLIENTARGS=--foobar
         self.assertEqual(em1_config, self.get_interface_config('em1'))
 
     def test_sriov_pf_ethtool_opts(self):
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
-            return
-        self.stub_out('os_net_config.utils.update_sriov_pf_map',
-                      test_update_sriov_pf_map)
         ifc = objects.SriovPF('enp3s0f0', 16,
                               ethtool_opts='speed 1000 duplex full')
         self.provider.add_interface(ifc)
@@ -1704,15 +1705,6 @@ NETMASK=255.255.255.0
         self.assertEqual(vf_config, self.get_interface_config('eth2_7'))
 
     def test_network_sriov_pf_without_promisc(self):
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
-            self.assertEqual(name, 'eth2')
-            self.assertEqual(numvfs, 10)
-            self.assertEqual(promisc, None)
-            self.assertEqual(link_mode, 'legacy')
-        self.stub_out('os_net_config.utils.update_sriov_pf_map',
-                      test_update_sriov_pf_map)
         nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1', 'nic3': 'eth2'}
         self.stubbed_mapped_nics = nic_mapping
 
@@ -1729,15 +1721,6 @@ BOOTPROTO=none
         self.assertEqual(pf_config, self.get_interface_config('eth2'))
 
     def test_network_sriov_pf_with_promisc_on(self):
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
-            self.assertEqual(name, 'eth2')
-            self.assertEqual(numvfs, 10)
-            self.assertTrue(promisc)
-            self.assertEqual(link_mode, 'legacy')
-        self.stub_out('os_net_config.utils.update_sriov_pf_map',
-                      test_update_sriov_pf_map)
         nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1', 'nic3': 'eth2'}
         self.stubbed_mapped_nics = nic_mapping
 
@@ -1754,15 +1737,6 @@ BOOTPROTO=none
         self.assertEqual(pf_config, self.get_interface_config('eth2'))
 
     def test_network_sriov_pf_with_promisc_off(self):
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
-            self.assertEqual(name, 'eth2')
-            self.assertEqual(numvfs, 10)
-            self.assertFalse(promisc)
-            self.assertEqual(link_mode, 'legacy')
-        self.stub_out('os_net_config.utils.update_sriov_pf_map',
-                      test_update_sriov_pf_map)
         nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1', 'nic3': 'eth2'}
         self.stubbed_mapped_nics = nic_mapping
 


### PR DESCRIPTION
This patch adds an option to configure multi queue for vDPA devices.

Change-Id: I0cf4b4296d784835d0164c81e7a910e975efcd34 (cherry picked from commit 384f46f8e0dfb847ab543e82f8cd08f5065edceb)