### PR TITLE
Raise exception when switchdev/vDPA is enabled with nmstate provider

### DIFF
--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -1534,6 +1534,10 @@ class NmstateNetConfig(os_net_config.NetConfig):
         :param sriov_pf: The SriovPF object to add
         """
         logger.info(f'adding sriov pf: {sriov_pf.name}')
+        if sriov_pf.vdpa or sriov_pf.link_mode == 'switchdev':
+            msg = "Switchdev/vDPA is not supported by nmstate provider yet."
+            raise os_net_config.ConfigurationError(msg)
+
         data = self._add_common(sriov_pf)
         data[Interface.TYPE] = InterfaceType.ETHERNET
         data[Ethernet.CONFIG_SUBTREE] = {}
@@ -1558,13 +1562,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
 
         if sriov_pf.promisc:
             data[Interface.ACCEPT_ALL_MAC_ADDRESSES] = True
-        if sriov_pf.link_mode == 'switchdev':
-            logger.info(f'enabling switchdev for sriov pf: {sriov_pf.name}')
-            data[Ethtool.CONFIG_SUBTREE] = {}
-            data[Ethtool.CONFIG_SUBTREE][Ethtool.Feature.CONFIG_SUBTREE] = {
-                'hw-tc-offload': True}
-        # Disable offload, in case default is set true
-        else:
+        if sriov_pf.link_mode == 'legacy':
             data[Ethtool.CONFIG_SUBTREE] = {}
             data[Ethtool.CONFIG_SUBTREE][Ethtool.Feature.CONFIG_SUBTREE] = {
                 'hw-tc-offload': False}

--- a/os_net_config/tests/test_impl_nmstate.py
+++ b/os_net_config/tests/test_impl_nmstate.py
@@ -1414,6 +1414,50 @@ class TestNmstateNetConfig(base.TestCase):
         self.assertEqual(yaml.safe_load(exp_pf_config),
                          self.get_interface_config('eth2'))
 
+    def test_sriov_pf_with_switchdev(self):
+        nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1', 'nic3': 'eth2'}
+        self.stubbed_mapped_nics = nic_mapping
+
+        def get_totalvfs_stub(iface_name):
+            return 10
+        self.stub_out('os_net_config.utils.get_totalvfs',
+                      get_totalvfs_stub)
+
+        def update_sriov_pf_map_stub(ifname, numvfs, noop, promisc=None,
+                                     link_mode='legacy', vdpa=False,
+                                     drivers_autoprobe=True,
+                                     steering_mode=None, lag_candidate=None):
+            return
+        self.stub_out('os_net_config.utils.update_sriov_pf_map',
+                      update_sriov_pf_map_stub)
+
+        pf = objects.SriovPF(name='nic3', numvfs=10, link_mode='switchdev')
+        self.assertRaises(os_net_config.ConfigurationError,
+                          self.provider.add_sriov_pf,
+                          pf)
+
+    def test_sriov_pf_with_vdpa(self):
+        nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1', 'nic3': 'eth2'}
+        self.stubbed_mapped_nics = nic_mapping
+
+        def get_totalvfs_stub(iface_name):
+            return 10
+        self.stub_out('os_net_config.utils.get_totalvfs',
+                      get_totalvfs_stub)
+
+        def update_sriov_pf_map_stub(ifname, numvfs, noop, promisc=None,
+                                     link_mode='legacy', vdpa=False,
+                                     drivers_autoprobe=True,
+                                     steering_mode=None, lag_candidate=None):
+            return
+        self.stub_out('os_net_config.utils.update_sriov_pf_map',
+                      update_sriov_pf_map_stub)
+
+        pf = objects.SriovPF(name='nic3', numvfs=10, vdpa=True)
+        self.assertRaises(os_net_config.ConfigurationError,
+                          self.provider.add_sriov_pf,
+                          pf)
+
     def test_sriov_pf_without_capability(self):
         nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1', 'nic3': 'eth2'}
         self.stubbed_mapped_nics = nic_mapping


### PR DESCRIPTION
Switchdev and vDPA are not supported yet with nmstate provider. ConfigurationError exception is raised when these features are used with nmstate provider.