### PR TITLE
Pin setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ PyYAML>=3.10.0 # MIT
 jsonschema>=3.2.0 # MIT
 pyudev>=0.16.1 # LGPLv2.1+
 pyroute2
+setuptools<71.0.0


### PR DESCRIPTION
Depends-On: https://github.com/os-net-config/os-net-config/pull/52

Cherry picking this fix as the tox CI issue was encountered in downstream rhos-17.1-trunk repo

Signed-off-by: Chandan Kumar (raukadah) <raukadah@gmail.com>
(cherry picked from commit d0e8449b00df09b95cd24dd9ddbd336e1d3bf070)