### PR TITLE
dcb: lazily import module

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -23,7 +23,6 @@ import sys
 import yaml
 
 from os_net_config import common
-from os_net_config import dcb_config
 from os_net_config import objects
 from os_net_config import utils
 from os_net_config import validator
@@ -404,6 +403,12 @@ def main(argv=sys.argv, main_logger=None):
 
     if utils.is_dcb_config_required():
         # Apply the DCB Config
+        try:
+            from os_net_config import dcb_config
+        except ImportError as e:
+            logger.error(f'cannot apply DCB configuration: {e!r}')
+            return 1
+
         utils.configure_dcb_config_service()
         dcb_apply = dcb_config.DcbApplyConfig()
         dcb_apply.apply()

--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -24,7 +24,6 @@ import netaddr
 from oslo_utils import strutils
 
 from os_net_config import common
-from os_net_config import dcb_netlink
 from os_net_config import utils
 
 
@@ -306,6 +305,8 @@ class Dcb(object):
 
     @staticmethod
     def from_json(json):
+        from os_net_config import dcb_netlink
+
         dscp2prio = []
         device = _get_required_field(json, 'device', 'Dcb')
         dscp2prio_lst = _get_required_field(json, 'dscp2prio', 'Dcb')


### PR DESCRIPTION
DCB relies on pyroute2 0.7 which isn't available everywhere. When the configuration does not require DCB, do not import the dcb_* related code to avoid any import errors.


(cherry picked from commit d2991f48b8722d1b438a1a355bc69d72669f6527)