### PR TITLE
DCB configurations over OVS DPDK BOND

### DIFF
--- a/os_net_config/schema.yaml
+++ b/os_net_config/schema.yaml
@@ -898,6 +898,8 @@ definitions:
                 $ref: "#/definitions/bool_or_param"
             domain:
                 $ref: "#/definitions/list_of_domain_name_string_or_domain_name_string"
+            dcb:
+                $ref: "#/definitions/dcb"
         required:
           - type
           - name


### PR DESCRIPTION
For the DCB configurations over a dpdkbond, currently the configs needs to be repeated under all the dpdk bond members (interfaces). This patch adds support in os-net-config to be able to apply DCB configurations directly under the object of type ovs dpdk bond.