### PR TITLE
SR-IOV configurations are made one after other for nmstate provider

### DIFF
--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -101,7 +101,12 @@ def is_dict_subset(superset, subset):
     if superset and subset:
         for key, value in subset.items():
             if key not in superset:
-                return False
+                # Items which are empty or false
+                # shall be considered as absent
+                if value:
+                    return False
+                else:
+                    continue
             if isinstance(value, dict):
                 if not is_dict_subset(superset[key], value):
                     return False
@@ -118,7 +123,14 @@ def is_dict_subset(superset, subset):
                 except TypeError:
                     for item in value:
                         if item not in superset[key]:
-                            return False
+                            if isinstance(item, dict):
+                                for s_items in superset[key]:
+                                    if is_dict_subset(s_items, item):
+                                        break
+                                else:
+                                    return False
+                            else:
+                                return False
             elif isinstance(value, set):
                 if not value <= superset[key]:
                     return False
@@ -240,6 +252,8 @@ class NmstateNetConfig(os_net_config.NetConfig):
         self.sriov_pf_data = {}
         self.sriov_vf_data = {}
         self.migration_enabled = False
+        self.apply_pf = False
+        self.apply_vf = False
         self.initial_state = netinfo.show_running_config()
         self.__dump_key_config(self.initial_state,
                                msg="Initial network settings")
@@ -321,11 +335,29 @@ class NmstateNetConfig(os_net_config.NetConfig):
                    f'while the VF {sriov_vf.vfid} is used')
             raise objects.InvalidConfigException(msg)
 
-    def prepare_sriov_vf_config(self):
-        iface_schema = []
+    def apply_pf_config(self, activate):
+        pf_config = []
+        for pf_name in self.sriov_pf_data.keys():
+            desired_pf_state = self.sriov_pf_data[pf_name]
+            cur_state = self.iface_state(pf_name)
+            if not is_dict_subset(cur_state, desired_pf_state):
+                if not self.noop and activate:
+                    logger.debug(f'{pf_name}: Applying the PF config')
+                    self.nmstate_apply(self.set_ifaces([desired_pf_state]),
+                                       verify=True)
+                pf_config.append(desired_pf_state)
 
+            else:
+                logger.info(f'{pf_name}: No changes required for PF')
+        self.apply_pf = False
+        return pf_config
+
+    def apply_vf_config(self, activate):
+        vf_config = []
         for pf in self.sriov_vf_data.keys():
             required_vfs = []
+            pf_state = {}
+
             if pf in self.sriov_pf_data:
                 pf_state = self.sriov_pf_data[pf]
 
@@ -337,12 +369,32 @@ class NmstateNetConfig(os_net_config.NetConfig):
                 if vf:
                     required_vfs.append(vf)
 
-            pf_state[
-                Ethernet.CONFIG_SUBTREE][
-                Ethernet.SRIOV_SUBTREE][
-                Ethernet.SRIOV.VFS_SUBTREE] = required_vfs
-            iface_schema.append(pf_state)
-        return iface_schema
+            if required_vfs and pf_state:
+                pf_state[
+                    Ethernet.CONFIG_SUBTREE][
+                    Ethernet.SRIOV_SUBTREE][
+                    Ethernet.SRIOV.VFS_SUBTREE] = required_vfs
+                cur_state = self.iface_state(pf_state['name'])
+                try:
+                    present_vf_state = cur_state[
+                        Ethernet.CONFIG_SUBTREE][Ethernet.SRIOV_SUBTREE]
+                    desire_vf_state = pf_state[
+                        Ethernet.CONFIG_SUBTREE][Ethernet.SRIOV_SUBTREE]
+                except KeyError:
+                    present_vf_state = cur_state
+                    desire_vf_state = pf_state
+                if not is_dict_subset(present_vf_state, desire_vf_state):
+                    if not self.noop and activate:
+                        logger.debug(f'{pf_state["name"]}: '
+                                     'Applying the VF parameters')
+                        self.nmstate_apply(self.set_ifaces([pf_state]),
+                                           verify=True)
+                    vf_config.append(pf_state)
+                else:
+                    logger.info(f'{pf_state["name"]}: '
+                                'No changes required for VFs')
+        self.apply_vf = False
+        return vf_config
 
     def get_route_tables(self):
         """Generate configuration content for routing tables.
@@ -1712,8 +1764,8 @@ class NmstateNetConfig(os_net_config.NetConfig):
 
         logger.debug('sriov pf data: %s' % data)
         self.sriov_vf_data[sriov_pf.name] = [None] * sriov_pf.numvfs
-        self.interface_data[sriov_pf.name] = data
         self.sriov_pf_data[sriov_pf.name] = data
+        self.apply_pf = True
 
     def add_sriov_vf(self, sriov_vf):
         """Add a SriovVF object to the net config object
@@ -1746,6 +1798,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
         if sriov_vf.ethtool_opts:
             self.add_ethtool_config(sriov_vf.name, data,
                                     sriov_vf.ethtool_opts)
+        self.apply_vf = True
 
     def add_ib_interface(self, ib_interface):
         """Add an InfiniBand interface object to the net config object.
@@ -1820,12 +1873,13 @@ class NmstateNetConfig(os_net_config.NetConfig):
 
         updated_interfaces = {}
         logger.debug("----------------------------")
-        vf_config = self.prepare_sriov_vf_config()
+        if self.apply_pf:
+            self.apply_pf_config(activate)
+
+        if self.apply_vf:
+            self.apply_vf_config(activate)
+
         apply_data = {}
-        if vf_config and activate:
-            if not self.noop:
-                logger.debug("Applying the VF parameters")
-                self.nmstate_apply(self.set_ifaces(vf_config), verify=True)
 
         for interface_name, iface_data in self.interface_data.items():
             iface_state = self.iface_state(interface_name)

--- a/os_net_config/tests/environment/netinfo_running_info_1.yaml
+++ b/os_net_config/tests/environment/netinfo_running_info_1.yaml
@@ -10,8 +10,38 @@ interfaces:
     duplex: full
     speed: 1000
     sr-iov:
-      total-vfs: 0
-      vfs: []
+      total-vfs: 3
+      vfs:
+      - id: 0
+        iface-name: ens1f1v0
+        mac-address: 3A:82:65:08:E3:4A
+        max-tx-rate: 0
+        min-tx-rate: 0
+        qos: 0
+        spoof-check: true
+        trust: false
+        vlan-id: 0
+        vlan-proto: 802.1q
+      - id: 1
+        iface-name: ens1f1v1
+        mac-address: BA:A2:60:4C:F9:DC
+        max-tx-rate: 0
+        min-tx-rate: 0
+        qos: 0
+        spoof-check: true
+        trust: false
+        vlan-id: 0
+        vlan-proto: 802.1q
+      - id: 2
+        iface-name: ens1f1v2
+        mac-address: 26:26:1B:11:07:DD
+        max-tx-rate: 0
+        min-tx-rate: 0
+        qos: 0
+        spoof-check: true
+        trust: false
+        vlan-id: 0
+        vlan-proto: 802.1q
   ethtool:
     coalesce:
       adaptive-rx: true
@@ -83,7 +113,7 @@ interfaces:
     enabled: false
   mac-address: E4:43:4B:5C:96:80
   mtu: 1500
-  name: eno1
+  name: eth1
   state: up
   type: ethernet
   wait-ip: any
@@ -148,7 +178,7 @@ interfaces:
     enabled: false
   mac-address: E4:43:4B:5C:96:81
   mtu: 1500
-  name: eno2
+  name: eth2
   state: down
   type: ethernet
 - accept-all-mac-addresses: false

--- a/os_net_config/tests/test_impl_nmstate.py
+++ b/os_net_config/tests/test_impl_nmstate.py
@@ -1427,26 +1427,26 @@ class TestNmstateNetConfig(base.TestCase):
         pf = objects.SriovPF(name='nic3', numvfs=10)
         self.provider.add_sriov_pf(pf)
         exp_pf_config = """
-        name: eth2
-        state: up
-        type: ethernet
-        ethernet:
+        - name: eth2
+          state: up
+          type: ethernet
+          ethernet:
             sr-iov:
-                total-vfs: 10
-                drivers-autoprobe: true
-        ethtool:
+              total-vfs: 10
+              drivers-autoprobe: true
+          ethtool:
             feature:
-                hw-tc-offload: False
-        ipv4:
+              hw-tc-offload: False
+          ipv4:
             dhcp: False
             enabled: False
-        ipv6:
+          ipv6:
             autoconf: False
             dhcp: False
             enabled: False
         """
         self.assertEqual(yaml.safe_load(exp_pf_config),
-                         self.get_interface_config('eth2'))
+                         self.provider.apply_pf_config(False))
 
     def test_sriov_pf_with_switchdev(self):
         nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1', 'nic3': 'eth2'}
@@ -1605,7 +1605,7 @@ class TestNmstateNetConfig(base.TestCase):
             other_config: { mac-table-size: 50000 }
         """
 
-        vf_config = self.provider.prepare_sriov_vf_config()
+        vf_config = self.provider.apply_vf_config(False)
         self.assertEqual(yaml.safe_load(exp_pf_config),
                          vf_config)
         self.assertEqual(yaml.safe_load(exp_bridge_config),
@@ -1684,7 +1684,7 @@ class TestNmstateNetConfig(base.TestCase):
             other_config: {'mac-table-size': 50000}
         """
 
-        vf_config = self.provider.prepare_sriov_vf_config()
+        vf_config = self.provider.apply_vf_config(False)
         self.assertEqual(yaml.safe_load(exp_pf_config),
                          vf_config)
         self.assertEqual(yaml.safe_load(exp_bridge_config),
@@ -2338,7 +2338,7 @@ class TestNmstateNetConfig(base.TestCase):
             other_config: {'mac-table-size': 50000}
         """
 
-        vf_config = self.provider.prepare_sriov_vf_config()
+        vf_config = self.provider.apply_vf_config(False)
         self.assertEqual(yaml.safe_load(exp_pf_config),
                          vf_config)
         self.assertEqual(yaml.safe_load(exp_bridge_config),
@@ -2473,7 +2473,7 @@ class TestNmstateNetConfig(base.TestCase):
             other_config: {'mac-table-size': 50000}
         """
 
-        vf_config = self.provider.prepare_sriov_vf_config()
+        vf_config = self.provider.apply_vf_config(False)
         self.assertEqual(yaml.safe_load(exp_pf_config),
                          vf_config)
         self.assertEqual(yaml.safe_load(exp_bridge_config),
@@ -2586,7 +2586,7 @@ class TestNmstateNetConfig(base.TestCase):
                 - eth2_3
         """
 
-        vf_config = self.provider.prepare_sriov_vf_config()
+        vf_config = self.provider.apply_vf_config(False)
         self.assertEqual(yaml.safe_load(exp_pf_config),
                          vf_config)
         self.assertEqual(yaml.safe_load(exp_bond_config),


### PR DESCRIPTION
SR-IOV configurations are applied one after the other. Its found that applying the SR-IOV configurations of all the NICs in one shot using nmstate results in failure 'Unable to configure VFs, other operation is pending` for i40e drivers.