### PR TITLE
Do not fail on schema validation errors

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -86,7 +86,7 @@ def parse_opts(argv):
         action='store_true',
         help="Exit with an error if configuration file validation fails. "
              "Without this option, just log a warning and continue.",
-        default=True)
+        default=False)
 
     parser.add_argument(
         '-d', '--debug',


### PR DESCRIPTION
There are use cases where we don't want to enforce the schema validation, like the current ovn-bgp-agent OpenStack deployments where we rely on "empty" bridges:

- type: ovs_bridge
  name: br-ex
  use_dhcp: false
- type: ovs_bridge
  name: br-vlan
  use_dhcp: false

It is left to the agent/kernel to set up routing and send traffic to the right nic(s).

This commit restore the previous behavior, where we emit a warning and continue.
It is left to the application/user to pass the --exit-on-validation-errors option at runtime if required.