### PR TITLE
Allow empty members for ovs_bridge

### DIFF
--- a/os_net_config/schema.yaml
+++ b/os_net_config/schema.yaml
@@ -587,6 +587,7 @@ definitions:
                       - $ref: "#/definitions/ovs_patch_port"
                       - $ref: "#/definitions/sriov_vf"
                       - $ref: "#/definitions/sriov_pf"
+                minItems: 0
             ovs_options:
                 $ref: "#/definitions/ovs_options_string_or_param"
             ovs_extra:
@@ -625,7 +626,6 @@ definitions:
         required:
           - type
           - name
-          - members
         additionalProperties: False
 
     ovs_user_bridge:

--- a/os_net_config/tests/test_validator.py
+++ b/os_net_config/tests/test_validator.py
@@ -310,6 +310,16 @@ class TestDeviceTypes(base.TestCase):
         }
         self.assertTrue(v.is_valid(data))
 
+    def test_ovs_bridge_with_empty_members(self):
+        schema = validator.get_schema_for_defined_type("ovs_bridge")
+        v = jsonschema.Draft4Validator(schema)
+        data = {
+            "type": "ovs_bridge",
+            "name": "br-ex",
+            "use_dhcp": "false"
+        }
+        self.assertTrue(v.is_valid(data))
+
     def test_ovs_bond(self):
         schema = validator.get_schema_for_defined_type("ovs_bond")
         v = jsonschema.Draft4Validator(schema)


### PR DESCRIPTION
Instead of allowing schema error (PR#100), updating schema for ovs_bridge to allow empty members:
There are use cases where we don't want to enforce the schema validation, like the current ovn-bgp-agent OpenStack deployments where we rely on "empty" bridges:

type: ovs_bridge
name: br-ex
use_dhcp: false
type: ovs_bridge
name: br-vlan
use_dhcp: false
It is left to the agent/kernel to set up routing and send traffic to the right nic.

Added test case for same

(cherry picked from commit 3ce3e2cefd30ced972148a5151ddf89a779348e3)