### PR TITLE
 noop: Run os-net-config without applying the changes

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -195,6 +195,9 @@ def is_nmstate_available():
 
 def main(argv=sys.argv, main_logger=None):
     opts = parse_opts(argv)
+
+    common.set_noop(opts.noop)
+
     if not main_logger:
         main_logger = common.configure_logger(log_file=not opts.noop)
     common.logger_level(main_logger, opts.verbose, opts.debug)

--- a/os_net_config/common.py
+++ b/os_net_config/common.py
@@ -84,6 +84,16 @@ class OvsDpdkBindException(ValueError):
     pass
 
 
+def set_noop(value):
+    global noop
+    noop = value
+
+
+def get_noop():
+    global noop
+    return noop
+
+
 def log_exceptions(type, value, tb):
     logger.exception(''.join(traceback.format_exception(
         type, value, tb)))

--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -1270,10 +1270,10 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         :param vpp_interface: The VppInterface object to add
         """
         vpp_interface.pci_dev = utils.get_pci_address(vpp_interface.name,
-                                                      False)
+                                                      self.noop)
         if not vpp_interface.pci_dev:
             vpp_interface.pci_dev = utils.get_stored_pci_address(
-                vpp_interface.name, False)
+                vpp_interface.name, self.noop)
         vpp_interface.hwaddr = common.interface_mac(vpp_interface.name)
         if not self.noop:
             self.ifdown(vpp_interface.name)

--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -1566,7 +1566,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
         data[Interface.TYPE] = OVSInterface.TYPE
         data[Interface.STATE] = InterfaceState.UP
 
-        pci_address = utils.get_dpdk_devargs(ifname, noop=False)
+        pci_address = utils.get_dpdk_devargs(ifname, noop=self.noop)
 
         data[OVSInterface.DPDK_CONFIG_SUBTREE
              ] = {OVSInterface.Dpdk.DEVARGS: pci_address}
@@ -1823,9 +1823,8 @@ class NmstateNetConfig(os_net_config.NetConfig):
         vf_config = self.prepare_sriov_vf_config()
         apply_data = {}
         if vf_config and activate:
-            if not self.noop:
-                logger.debug("Applying the VF parameters")
-                self.nmstate_apply(self.set_ifaces(vf_config), verify=True)
+            logger.debug("Applying the VF parameters")
+            self.nmstate_apply(self.set_ifaces(vf_config), verify=True)
 
         for interface_name, iface_data in self.interface_data.items():
             iface_state = self.iface_state(interface_name)
@@ -1875,15 +1874,15 @@ class NmstateNetConfig(os_net_config.NetConfig):
 
         if updated_interfaces:
             apply_data = self.set_ifaces(list(updated_interfaces.values()))
-            if activate and not self.noop:
+            if activate:
                 self.nmstate_apply(apply_data, verify=True)
         if del_routes:
             apply_data = self.set_routes(del_routes)
-            if activate and not self.noop:
+            if activate:
                 self.nmstate_apply(apply_data, verify=True)
         if add_routes:
             apply_data = self.set_routes(add_routes)
-            if activate and not self.noop:
+            if activate:
                 self.nmstate_apply(apply_data, verify=True)
 
         if config_rules_dns:
@@ -1891,16 +1890,16 @@ class NmstateNetConfig(os_net_config.NetConfig):
 
             if del_rules:
                 apply_data = self.set_rules(del_rules)
-                if activate and not self.noop:
+                if activate:
                     self.nmstate_apply(apply_data, verify=True)
 
             if add_rules:
                 apply_data = self.set_rules(add_rules)
-                if activate and not self.noop:
+                if activate:
                     self.nmstate_apply(apply_data, verify=True)
 
             apply_data = self.set_dns()
-            if activate and not self.noop:
+            if activate:
                 self.nmstate_apply(apply_data, verify=True)
 
         if activate:

--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -298,10 +298,11 @@ class Dcb(object):
     """Base class for DCB configuration"""
 
     def __init__(self, device, dscp2prio=[]):
+        noop = common.get_noop()
         self.device = device
         self.dscp2prio = dscp2prio
-        self.pci_addr = utils.get_pci_address(device, False)
-        self.driver = utils.get_driver(device, False)
+        self.pci_addr = utils.get_pci_address(device, noop)
+        self.driver = utils.get_driver(device, noop)
 
     @staticmethod
     def from_json(json):
@@ -537,8 +538,9 @@ class Interface(_BaseOpts):
                 device = name
             dcb_config_json['device'] = device
             dcb_config = Dcb.from_json(dcb_config_json)
+            noop = common.get_noop()
             common.update_dcb_map(device=device, pci_addr=dcb_config.pci_addr,
-                                  driver=dcb_config.driver, noop=False,
+                                  driver=dcb_config.driver, noop=noop,
                                   dscp2prio=dcb_config.dscp2prio)
 
         return Interface(name, *opts, ethtool_opts=ethtool_opts,
@@ -1087,9 +1089,10 @@ class LinuxBond(_BaseOpts):
         self.members = members
         self.bonding_options = bonding_options
         self.ethtool_opts = ethtool_opts
+        noop = common.get_noop()
         for member in self.members:
             if isinstance(member, SriovPF):
-                utils.update_sriov_pf_map(member.name, member.numvfs, False,
+                utils.update_sriov_pf_map(member.name, member.numvfs, noop,
                                           promisc=member.promisc,
                                           steering_mode=member.steering_mode,
                                           link_mode=member.link_mode,
@@ -1550,9 +1553,10 @@ class SriovVF(_BaseOpts):
         self.spoofcheck = spoofcheck
         self.trust = trust
         self.state = state
-        pci_address = utils.get_pci_address(name, False)
+        noop = common.get_noop()
+        pci_address = utils.get_pci_address(name, noop)
         if pci_address is None:
-            pci_address = utils.get_stored_pci_address(name, False)
+            pci_address = utils.get_stored_pci_address(name, noop)
         self.macaddr = macaddr
         self.promisc = promisc
         self.pci_address = pci_address
@@ -1646,7 +1650,8 @@ class SriovPF(_BaseOpts):
         self.ethtool_opts = ethtool_opts
         self.vdpa = vdpa
         self.steering_mode = steering_mode
-        utils.update_sriov_pf_map(self.name, self.numvfs, False,
+        noop = common.get_noop()
+        utils.update_sriov_pf_map(self.name, self.numvfs, noop,
                                   promisc=self.promisc,
                                   link_mode=self.link_mode,
                                   vdpa=self.vdpa,
@@ -1705,8 +1710,9 @@ class SriovPF(_BaseOpts):
                 device = name
             dcb_config_json['device'] = device
             dcb_config = Dcb.from_json(dcb_config_json)
+            noop = common.get_noop()
             common.update_dcb_map(device=device, pci_addr=dcb_config.pci_addr,
-                                  driver=dcb_config.driver, noop=False,
+                                  driver=dcb_config.driver, noop=noop,
                                   dscp2prio=dcb_config.dscp2prio)
 
         opts = _BaseOpts.base_opts_from_json(json)

--- a/os_net_config/utils.py
+++ b/os_net_config/utils.py
@@ -322,7 +322,7 @@ def get_driver(ifname, noop):
 def translate_ifname_to_pci_address(ifname, noop):
     pci_address = get_stored_pci_address(ifname, noop)
     if pci_address is None and not noop:
-        pci_address = get_pci_address(ifname, noop=False)
+        pci_address = get_pci_address(ifname, noop=noop)
         mac_address = common.interface_mac(ifname)
         _update_dpdk_map(ifname, pci_address, mac_address, driver=None)
     return pci_address


### PR DESCRIPTION
When os-net-config is run with noop, its failing due to permission issues or trying to write files and configure devices. When `noop` is used, there shall be no changes made to the machine, while the configuration files or templates derived shall be output on the console. This is done so that the template/compatibility issues of the config.yaml could be validated on a given hardware without changing the system files or configuration.