### PR TITLE
ifcfg: Fix linux bridge

### DIFF
--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -1703,8 +1703,8 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                 update_files[br_route_path] = route_data
                 if bridge_name not in restart_bridges:
                     apply_routes.append((bridge_name, route_data))
-            if utils.diff(route6_path, route6_data):
-                update_files[route6_path] = route6_data
+            if utils.diff(br_route6_path, route6_data):
+                update_files[br_route6_path] = route6_data
                 if bridge_name not in restart_bridges:
                     apply_routes.append((bridge_name, route6_data))
             if utils.diff(br_rule_path, rule_data):


### PR DESCRIPTION
When trying to create a Linux Bridge with something like

```
- type: linux_bridge
  name: br-ex
  mtu: 1500
  use_dhcp: false
  dns_servers: ['192.168.140.80']
  domain: ['ctlplane.example.com', 'internalapi.example.com', 'storage.example.com', 'tenant.example.com']
  addresses:
  - ip_netmask: 192.168.140.100/24
  routes: [{'destination': '0.0.0.0/0', 'nexthop': '192.168.140.1'}]
```

We get and exception saying that `route6_path` variable was used before assignment.

That happens because the variable is actually called `br_route6_path`, and this patch fixes this.