### PR TITLE
adding the option to add route though next-hop-interface

### DIFF
--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -992,9 +992,15 @@ class NmstateNetConfig(os_net_config.NetConfig):
             if route.ip_netmask:
                 route_data[NMRoute.DESTINATION] = route.ip_netmask
             if route.next_hop:
-                route_data[NMRoute.NEXT_HOP_ADDRESS] = route.next_hop
-                route_data[NMRoute.NEXT_HOP_INTERFACE] = interface_name
+                if route.next_hop == "self":
+                    route_data[NMRoute.NEXT_HOP_INTERFACE] = interface_name
+                else:
+                    route_data[NMRoute.NEXT_HOP_ADDRESS] = route.next_hop
+                    route_data[NMRoute.NEXT_HOP_INTERFACE] = interface_name
                 if route.default:
+                    if route.next_hop == "self":
+                        msg = "self as next_hop allowed only with ip_netmask"
+                        raise os_net_config.ConfigurationError(msg)
                     if ":" in route.next_hop:
                         route_data[NMRoute.DESTINATION] = \
                             IPV6_DEFAULT_GATEWAY_DESTINATION

--- a/os_net_config/schema.yaml
+++ b/os_net_config/schema.yaml
@@ -121,7 +121,9 @@ definitions:
         type: string
         pattern: >-
           ^(?=^.{1,255}$)(?!.*\.\..*)(.{1,63}\.)+(.{0,63}\.?)|(?!\.)(?!.*\.\..*)(^.{1,63}$)|(^\.$)$
-
+    self_interface:
+        type: string
+        pattern: "^self$"
     list_of_domain_name_string_or_domain_name_string:
         oneOf:
           - type: array
@@ -169,7 +171,9 @@ definitions:
         oneOf:
         - properties:
             next_hop:
-                $ref: "#/definitions/ip_address_string_or_param"
+              oneOf:
+                - $ref: "#/definitions/ip_address_string_or_param"
+                - $ref: "#/definitions/self_interface"
             ip_netmask:
                 $ref: "#/definitions/ip_cidr_string_or_param"
             default:


### PR DESCRIPTION
nmstate support to add route to interface through local device ( ip r add default dev ). 
Not defining next-hop-address is equal to next-hop-address: 0.0.0.0