### PR TITLE
ifcfg: Remove duplicate ovs_extra for DPDK bond

### DIFF
--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -648,7 +648,6 @@ class IfcfgNetConfig(os_net_config.NetConfig):
             data += "OVS_BRIDGE=%s\n" % base_opt.bridge_name
             data += "OVS_PATCH_PEER=%s\n" % base_opt.peer
         elif isinstance(base_opt, objects.OvsDpdkPort):
-            ovs_extra.extend(base_opt.ovs_extra)
             data += "DEVICETYPE=ovs\n"
             data += "TYPE=OVSDPDKPort\n"
             data += "OVS_BRIDGE=%s\n" % base_opt.bridge_name
@@ -675,8 +674,8 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                 data += "TX_QUEUE_SIZE=%i\n" % base_opt.tx_queue_size
                 ovs_extra.append("set Interface $DEVICE " +
                                  "options:n_txq_desc=$TX_QUEUE_SIZE")
-        elif isinstance(base_opt, objects.OvsDpdkBond):
             ovs_extra.extend(base_opt.ovs_extra)
+        elif isinstance(base_opt, objects.OvsDpdkBond):
             # Referring to bug:1643026, the below commenting of the interfaces,
             # is to workaround the error, but is not the long term solution.
             # The long term solution is to run DPDK options before

--- a/os_net_config/tests/test_impl_ifcfg.py
+++ b/os_net_config/tests/test_impl_ifcfg.py
@@ -1902,8 +1902,10 @@ OVS_EXTRA="set Interface $DEVICE options:dpdk-devargs=0000:00:09.0 \
         self.stubbed_mapped_nics = nic_mapping
 
         interface = objects.Interface(name='nic3')
+        ovs_extra = ['set interface dpdk0 options:dpdk-lsc-interrupt=true']
         dpdk_port = objects.OvsDpdkPort(name='dpdk0', members=[interface],
-                                        mtu=9000, rx_queue=4)
+                                        mtu=9000, rx_queue=4,
+                                        ovs_extra=ovs_extra)
         bridge = objects.OvsUserBridge('br-link', members=[dpdk_port])
 
         def test_bind_dpdk_interfaces(ifname, driver, noop):
@@ -1938,7 +1940,8 @@ RX_QUEUE=4
 MTU=9000
 OVS_EXTRA="set Interface $DEVICE options:dpdk-devargs=0000:00:09.0 \
 -- set Interface $DEVICE mtu_request=$MTU \
--- set Interface $DEVICE options:n_rxq=$RX_QUEUE"
+-- set Interface $DEVICE options:n_rxq=$RX_QUEUE \
+-- set interface dpdk0 options:dpdk-lsc-interrupt=true"
 """
         self.assertEqual(br_link_config,
                          self.provider.bridge_data['br-link'])
@@ -2013,7 +2016,10 @@ OVS_EXTRA="set Interface dpdk0 options:dpdk-devargs=0000:00:08.0 \
         iface1 = objects.Interface(name='nic2')
         dpdk1 = objects.OvsDpdkPort(name='dpdk1',
                                     members=[iface1], driver='mlx5_core')
-        bond = objects.OvsDpdkBond('dpdkbond0', members=[dpdk0, dpdk1])
+        ovs_extra = ['set interface dpdk0 options:dpdk-lsc-interrupt=true',
+                     'set interface dpdk1 options:dpdk-lsc-interrupt=true']
+        bond = objects.OvsDpdkBond('dpdkbond0', members=[dpdk0, dpdk1],
+                                   ovs_extra=ovs_extra)
         bridge = objects.OvsUserBridge('br-link', members=[bond])
 
         def test_bind_dpdk_interfaces(ifname, driver, noop):
@@ -2038,7 +2044,9 @@ TYPE=OVSDPDKBond
 OVS_BRIDGE=br-link
 BOND_IFACES="dpdk0 dpdk1"
 OVS_EXTRA="set Interface dpdk0 options:dpdk-devargs=0000:00:01.0 \
--- set Interface dpdk1 options:dpdk-devargs=0000:00:02.0"
+-- set Interface dpdk1 options:dpdk-devargs=0000:00:02.0 \
+-- set interface dpdk0 options:dpdk-lsc-interrupt=true \
+-- set interface dpdk1 options:dpdk-lsc-interrupt=true"
 """
         self.assertEqual(dpdk_bond_config,
                          self.get_interface_config('dpdkbond0'))


### PR DESCRIPTION
The ovs_extra field of ovs_dpdk_bond is duplicated in the ifcfg files. The duplicate entries are prevented from modifying the ifcfg files. Also the user specified ovs_extra fields are moved after the os-net-config generated ovs_extra commands.

(cherry picked from commit b58e61b7387318df4776a7b6cdcf78a9bd53dda3)
Signed-off-by: Karthik Sundaravel <ksundara@redhat.com>