### PR TITLE
bond: fix to match the mac address with appropriate interface

### DIFF
--- a/os_net_config/common.py
+++ b/os_net_config/common.py
@@ -272,7 +272,7 @@ def _get_dpdk_mac_address(name):
 
 def interface_mac(name):
     try:  # If the iface is part of a Linux bond, the real MAC is only here.
-        with open(get_dev_path(name, 'bonding_slave/perm_hwaddr'),
+        with open(get_dev_path(name, '_bonding_slave/perm_hwaddr'),
                   'r') as f:
             return f.read().rstrip()
     except IOError:


### PR DESCRIPTION
When running 'os-net-config -i' getting below error ERROR os_net_config.objects.mapped_nics mac
f8:f2:1e:03:a5:c2 not found in available nics

Fixing the path of the appropriate interface.