### PR TITLE
Pf given to guest

### DIFF
--- a/os_net_config/common.py
+++ b/os_net_config/common.py
@@ -409,6 +409,16 @@ def _get_sriov_mac_address(iface_name):
         return sriov_map[0].get('mac_address', None)
 
 
+def is_pf_attached_to_guest(iface_name):
+    driver = None
+    pci_addr = get_sriov_pci_address(iface_name)
+    if pci_addr:
+        driver = get_pci_device_driver(pci_addr)
+    if driver == 'vfio-pci':
+        return True
+    return False
+
+
 def is_vf_by_name(interface_name, check_mapping_file=False):
     vf_path_check = get_dev_path(interface_name, 'physfn')
     is_sriov_vf = os.path.isdir(vf_path_check)

--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -2134,6 +2134,11 @@ class NmstateNetConfig(os_net_config.NetConfig):
                 "by nmstate provider yet."
             )
             raise os_net_config.ConfigurationError(msg)
+        if common.is_pf_attached_to_guest(sriov_pf.name):
+            logger.info(
+                "%s: Attached to guest, skip configuring", sriov_pf.name
+            )
+            return
 
         data = self._add_common(sriov_pf)
         data[Interface.TYPE] = InterfaceType.ETHERNET

--- a/os_net_config/sriov_config.py
+++ b/os_net_config/sriov_config.py
@@ -407,6 +407,11 @@ def configure_sriov_pf(execution_from_cli=False, restart_openvswitch=False):
 
     for item in sriov_map:
         if item['device_type'] == 'pf':
+            if common.is_pf_attached_to_guest(item['name']):
+                logger.info(
+                    "%s: Attached to guest, skip configuring", item["name"]
+                )
+                continue
             if pf_configure_status(item):
                 logger.debug("%s: SR-IOV already configured", item["name"])
                 continue
@@ -942,6 +947,12 @@ def main(argv=sys.argv):
     if opts.numvfs:
         if re.match(r"^\w+:\d+$", opts.numvfs):
             device_name, numvfs = opts.numvfs.split(':')
+            if common.is_pf_attached_to_guest(device_name):
+                logger.info(
+                    "%s: Attached to guest, skipping PF config",
+                    device_name
+                )
+                return 0
             pfs = common.get_sriov_map(device_name)
             if pfs:
                 autoprobe = pfs[0].get('drivers_autoprobe', True)


### PR DESCRIPTION
sriov: Skip PF configuration when its attached to guest
  
In scenarios where the PF is attached to the guest, the PF device will not be visible in the hosts net subsystem. And if os-net-config is rerun in that scenario, the NIC mapping would fail. Checks shall be added so that the situation where the PF is attached to the guest is detected and handled.