### PR TITLE
sriov: Handle NIC partitioning while autoprobe is disabled

### DIFF
--- a/os_net_config/common.py
+++ b/os_net_config/common.py
@@ -434,6 +434,25 @@ def is_vf_by_name(interface_name, check_mapping_file=False):
     return is_sriov_vf
 
 
+def get_default_vf_driver(pf_name, vfid):
+    modalias_path = get_dev_path(pf_name, f"virtfn{vfid}/modalias")
+    try:
+        with open(modalias_path) as f:
+            alias = f.read().strip()
+        cmd = ["modprobe", "-R", alias]
+        out, err = processutils.execute(*cmd)
+        kernel_driver = out.strip()
+        logger.info(
+            "%s-%d: default vf driver is %s", pf_name, vfid, kernel_driver
+        )
+        return kernel_driver
+    except (OSError, processutils.ProcessExecutionError) as e:
+        logger.error(
+            "%s-%d: failed to get default vf driver: %s", pf_name, vfid, e
+        )
+        return None
+
+
 def set_driverctl_override(pci_address, driver):
     if driver is None:
         logger.info("%s: Driver override is not required.", pci_address)

--- a/os_net_config/tests/test_cli.py
+++ b/os_net_config/tests/test_cli.py
@@ -237,12 +237,22 @@ class TestCli(base.TestCase):
         def test_interface_mac(name):
             return 'AA:BB:CC:DD:EE:FF'
 
+        def test_get_default_vf_driver(device, vfid):
+            return 'iavf'
+
+        def test_get_pci_device_driver(pci_address):
+            return 'iavf'
+
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
         self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
         self.stub_out('os_net_config.common.interface_mac',
                       test_interface_mac)
+        self.stub_out('os_net_config.common.get_default_vf_driver',
+                      test_get_default_vf_driver)
+        self.stub_out('os_net_config.common.get_pci_device_driver',
+                      test_get_pci_device_driver)
         ivs_yaml = os.path.join(SAMPLE_BASE, 'sriov_pf.yaml')
         ivs_json = os.path.join(SAMPLE_BASE, 'sriov_pf.json')
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
@@ -270,10 +280,20 @@ class TestCli(base.TestCase):
         def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
+        def test_get_default_vf_driver(device, vfid):
+            return 'iavf'
+
+        def test_get_pci_device_driver(pci_address):
+            return 'iavf'
+
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
         self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
+        self.stub_out('os_net_config.common.get_default_vf_driver',
+                      test_get_default_vf_driver)
+        self.stub_out('os_net_config.common.get_pci_device_driver',
+                      test_get_pci_device_driver)
         pf_yaml = os.path.join(SAMPLE_BASE, 'sriov_pf_ovs_dpdk.yaml')
         pf_json = os.path.join(SAMPLE_BASE, 'sriov_pf_ovs_dpdk.json')
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '


### PR DESCRIPTION
sriov: Handle NIC partitioning while autoprobe is disabled
    
When drivers_autoprobe is disabled for sriov_pf, the VFs created
will not be bound with the required net drivers and hence those
VFs would not be listed in the /sys/class/net/<vf name>.
In order to make the NIC partitioning functional the required drivers
needs to be bounded with the VF.