### PR TITLE
fix missing f-string in rollback log

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -398,7 +398,7 @@ def main(argv=sys.argv, main_logger=None):
                      f'provider***\n{e!r}')
 
         if purge_provider:
-            logger.info('Rolling back to {opts.purge_provider}')
+            logger.info(f'Rolling back to {opts.purge_provider}')
             # Rolling back to the earlier provider.
             purge_provider.roll_back_migration()
             migration_failed = True


### PR DESCRIPTION
(cherry picked from commit 2676e9b89347b4ffbb32981eb919598ca5000c0e)
Signed-off-by: Abhiram R N <abhiramrn@gmail.com>