### PR TITLE
noop: fix noop run for nic partitioning use case

### DIFF
--- a/os_net_config/common.py
+++ b/os_net_config/common.py
@@ -183,6 +183,9 @@ def get_file_data(filename):
 
 
 def write_yaml_config(filepath, data):
+    if get_noop():
+        logger.info("Writing file %s with content %s", filepath, data)
+        return
     os.makedirs(os.path.dirname(filepath), exist_ok=True)
     with open(filepath, 'w') as f:
         yaml.safe_dump(data, f, default_flow_style=False)

--- a/os_net_config/tests/test_cli.py
+++ b/os_net_config/tests/test_cli.py
@@ -249,15 +249,10 @@ class TestCli(base.TestCase):
                                            '--exit-on-validation-errors '
                                            '-c %s' % ivs_yaml)
         self.assertEqual('', stderr)
-        contents = common.get_file_data(common.SRIOV_CONFIG_FILE)
-        sriov_config_yaml = yaml.safe_load(contents)
-        os.remove(common.SRIOV_CONFIG_FILE)
         stdout_json, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
                                            '--exit-on-validation-errors '
                                            '-c %s' % ivs_json)
         self.assertEqual('', stderr)
-        contents = common.get_file_data(common.SRIOV_CONFIG_FILE)
-        sriov_config_json = yaml.safe_load(contents)
         sanity_devices = ['DEVICE=p2p1',
                           'DEVICE=p2p1_5',
                           'DEVICE=p2p1_1',
@@ -267,7 +262,6 @@ class TestCli(base.TestCase):
         for dev in sanity_devices:
             self.assertIn(dev, stdout_yaml)
         self.assertEqual(stdout_yaml, stdout_json)
-        self.assertCountEqual(sriov_config_yaml, sriov_config_json)
 
     def test_sriov_vf_with_dpdk_noop_output(self):
         def test_get_vf_devname(device, vfid):
@@ -286,15 +280,10 @@ class TestCli(base.TestCase):
                                            '--exit-on-validation-errors '
                                            '-c %s' % pf_yaml)
         self.assertEqual('', stderr)
-        contents = common.get_file_data(common.SRIOV_CONFIG_FILE)
-        sriov_config_yaml = yaml.safe_load(contents)
-        os.remove(common.SRIOV_CONFIG_FILE)
         stdout_json, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
                                            '--exit-on-validation-errors '
                                            '-c %s' % pf_json)
         self.assertEqual('', stderr)
-        contents = common.get_file_data(common.SRIOV_CONFIG_FILE)
-        sriov_config_json = yaml.safe_load(contents)
         sanity_devices = ['DEVICE=p2p1',
                           'DEVICE=p2p1_5',
                           'DEVICE=br-vfs',
@@ -304,7 +293,6 @@ class TestCli(base.TestCase):
         for dev in sanity_devices:
             self.assertIn(dev, stdout_yaml)
         self.assertEqual(stdout_yaml, stdout_json)
-        self.assertCountEqual(sriov_config_yaml, sriov_config_json)
 
     def test_ovs_dpdk_bond_noop_output(self):
         ivs_yaml = os.path.join(SAMPLE_BASE, 'ovs_dpdk_bond.yaml')

--- a/os_net_config/tests/test_objects.py
+++ b/os_net_config/tests/test_objects.py
@@ -437,7 +437,7 @@ class TestBridge(base.TestCase):
 
     def setUp(self):
         super(TestBridge, self).setUp()
-        common.set_noop(True)
+        common.set_noop(False)
         rand = str(int(random.random() * 100000))
         common.SRIOV_CONFIG_FILE = '/tmp/sriov_config_' + rand + '.yaml'
 
@@ -1222,7 +1222,7 @@ class TestLinuxBond(base.TestCase):
 
     def setUp(self):
         super(TestLinuxBond, self).setUp()
-        common.set_noop(True)
+        common.set_noop(False)
         rand = str(int(random.random() * 100000))
         common.SRIOV_CONFIG_FILE = '/tmp/sriov_config_' + rand + '.yaml'
 

--- a/os_net_config/tests/test_sriov_bind_config.py
+++ b/os_net_config/tests/test_sriov_bind_config.py
@@ -30,6 +30,7 @@ class TestSriovBindConfig(base.TestCase):
     def setUp(self):
         super(TestSriovBindConfig, self).setUp()
         rand = str(int(random.random() * 100000))
+        common.set_noop(False)
 
         sriov_bind_config._SRIOV_BIND_CONFIG_FILE = '/tmp/' + rand +\
             'sriov_bind_config.yaml'

--- a/os_net_config/tests/test_sriov_config.py
+++ b/os_net_config/tests/test_sriov_config.py
@@ -32,6 +32,7 @@ class TestSriovConfig(base.TestCase):
     def setUp(self):
         super(TestSriovConfig, self).setUp()
         rand = str(int(random.random() * 100000))
+        common.set_noop(False)
 
         def execute_noop(*args, **kw):
             pass

--- a/os_net_config/tests/test_utils.py
+++ b/os_net_config/tests/test_utils.py
@@ -98,6 +98,7 @@ class TestUtils(base.TestCase):
         common.SRIOV_CONFIG_FILE = '/tmp/sriov_config_' + rand + '.yaml'
         common._LOG_FILE = '/tmp/' + rand + 'os_net_config.log'
         sriov_config._UDEV_LEGACY_RULE_FILE = UDEV_FILE + rand
+        common.set_noop(False)
 
     def tearDown(self):
         super(TestUtils, self).tearDown()


### PR DESCRIPTION
The noop dry run attempts to write to the sriov map, which results in failure for non privileged users. The fix is to avoid writing to the map files during dry run.