### PR TITLE
avoid KeyError: 'drivers_autoprobe' when use os-net-config-sriov

### DIFF
--- a/os_net_config/sriov_config.py
+++ b/os_net_config/sriov_config.py
@@ -423,8 +423,9 @@ def configure_sriov_pf(execution_from_cli=False, restart_openvswitch=False):
             # It has to happen before we set_numvfs
             if vdpa and is_mlnx:
                 configure_switchdev(item['name'])
-            set_drivers_autoprobe(item['name'], item['drivers_autoprobe'])
-            set_numvfs(item['name'], item['numvfs'], item['drivers_autoprobe'])
+            autoprobe = item.get('drivers_autoprobe', True)
+            set_drivers_autoprobe(item['name'], autoprobe)
+            set_numvfs(item['name'], item['numvfs'], autoprobe)
             # Configure switchdev, unbind driver and configure vdpa
             if item.get('link_mode') == "switchdev" and is_mlnx:
                 logger.info(f"{item['name']}: Mellanox card")


### PR DESCRIPTION
When sriov_config service is run after updating the os-net-config package in an existing deployment, we get the error “KeyError: ‘drivers_autoprobe’“. This is due to the previously configured sriov_config.yaml which does not have the `drivers_autoprobe` field. Adding a check for the existence of the ’drivers_autoprobe` field to avoid the error

(cherry picked from commit a35d78ade8374deef4a471f466a51c11acd0be64)
Signed-off-by: Abhiram R N <abhiramrn@gmail.com>