### PR TITLE
dpdk: Bind the VFs with the drivers using dispatcher scripts

### DIFF
--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -1439,7 +1439,9 @@ class OvsDpdkPort(_BaseOpts):
         if iface.promisc is not None:
             logger.warning("Promisc can't be changed for ovs_dpdk_port")
             iface.promisc = None
-        logger.info("Overriding the default driver for DPDK")
+        logger.info(f'{iface.device}-{iface.vfid}: Overriding the default '
+                    f'driver for DPDK with {driver}')
+        iface.driver = driver
         utils.update_sriov_vf_map(iface.device, iface.vfid, iface.name,
                                   vlan_id=iface.vlan_id, qos=iface.qos,
                                   spoofcheck=iface.spoofcheck,

--- a/os_net_config/tests/test_impl_nmstate.py
+++ b/os_net_config/tests/test_impl_nmstate.py
@@ -195,6 +195,10 @@ class TestNmstateNetConfig(base.TestCase):
         super(TestNmstateNetConfig, self).setUp()
         common.set_noop(True)
 
+        impl_nmstate._VF_BIND_DRV_SCRIPT = (
+            'dpdk_vfs="{dpdk_vfs}"\n'
+            'linux_vfs="{linux_vfs}"')
+
         def show_running_info_stub():
             running_info_path = os.path.join(
                 os.path.dirname(__file__),
@@ -1557,6 +1561,10 @@ class TestNmstateNetConfig(base.TestCase):
               autoconf: False
               dhcp: False
               enabled: False
+          dispatch:
+              post-activation: |
+                  dpdk_vfs=""
+                  linux_vfs="2"
         - name: eth1
           state: up
           type: ethernet
@@ -1580,6 +1588,10 @@ class TestNmstateNetConfig(base.TestCase):
               autoconf: False
               dhcp: False
               enabled: False
+          dispatch:
+              post-activation: |
+                  dpdk_vfs=""
+                  linux_vfs="2"
         """
 
         exp_bridge_config = """
@@ -1617,6 +1629,12 @@ class TestNmstateNetConfig(base.TestCase):
     def test_sriov_pf_with_nicpart_ovs_user_bridge_no_bond(self):
         nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1', 'nic3': 'eth2'}
         self.stubbed_mapped_nics = nic_mapping
+
+        def stub_get_pci_address(ifname, noop):
+            if 'eth1_2' in ifname:
+                return "0000:00:07.1"
+        self.stub_out('os_net_config.utils.get_pci_address',
+                      stub_get_pci_address)
 
         pf2 = objects.SriovPF(name='nic2', numvfs=10)
         self.provider.add_sriov_pf(pf2)
@@ -1666,6 +1684,10 @@ class TestNmstateNetConfig(base.TestCase):
               autoconf: False
               dhcp: False
               enabled: False
+          dispatch:
+              post-activation: |
+                  dpdk_vfs="2"
+                  linux_vfs=""
         """
 
         exp_bridge_config = """
@@ -2220,6 +2242,14 @@ class TestNmstateNetConfig(base.TestCase):
         nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1', 'nic3': 'eth2'}
         self.stubbed_mapped_nics = nic_mapping
 
+        def stub_get_pci_address(ifname, noop):
+            if 'eth1_2' in ifname:
+                return "0000:00:07.1"
+            if 'eth2_2' in ifname:
+                return "0000:00:07.2"
+        self.stub_out('os_net_config.utils.get_pci_address',
+                      stub_get_pci_address)
+
         pf1 = objects.SriovPF(name='nic3', numvfs=10)
         self.provider.add_sriov_pf(pf1)
         pf2 = objects.SriovPF(name='nic2', numvfs=10)
@@ -2289,6 +2319,10 @@ class TestNmstateNetConfig(base.TestCase):
               autoconf: False
               dhcp: False
               enabled: False
+          dispatch:
+              post-activation: |
+                  dpdk_vfs="2"
+                  linux_vfs=""
         - name: eth1
           state: up
           type: ethernet
@@ -2312,6 +2346,10 @@ class TestNmstateNetConfig(base.TestCase):
               autoconf: False
               dhcp: False
               enabled: False
+          dispatch:
+              post-activation: |
+                  dpdk_vfs="2"
+                  linux_vfs=""
         """
 
         exp_bridge_config = """
@@ -2351,6 +2389,14 @@ class TestNmstateNetConfig(base.TestCase):
         nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1', 'nic3': 'eth2'}
         self.stubbed_mapped_nics = nic_mapping
 
+        def stub_get_pci_address(ifname, noop):
+            if 'eth1_2' in ifname:
+                return "0000:00:07.1"
+            if 'eth2_2' in ifname:
+                return "0000:00:07.2"
+        self.stub_out('os_net_config.utils.get_pci_address',
+                      stub_get_pci_address)
+
         pf1 = objects.SriovPF(name='nic3', numvfs=10)
         self.provider.add_sriov_pf(pf1)
         pf2 = objects.SriovPF(name='nic2', numvfs=10)
@@ -2424,6 +2470,10 @@ class TestNmstateNetConfig(base.TestCase):
               autoconf: False
               dhcp: False
               enabled: False
+          dispatch:
+              post-activation: |
+                  dpdk_vfs="2"
+                  linux_vfs=""
         - name: eth1
           state: up
           type: ethernet
@@ -2447,6 +2497,10 @@ class TestNmstateNetConfig(base.TestCase):
               autoconf: False
               dhcp: False
               enabled: False
+          dispatch:
+              post-activation: |
+                  dpdk_vfs="2"
+                  linux_vfs=""
         """
 
         exp_bridge_config = """
@@ -2541,6 +2595,10 @@ class TestNmstateNetConfig(base.TestCase):
               autoconf: False
               dhcp: False
               enabled: False
+          dispatch:
+              post-activation: |
+                  dpdk_vfs=""
+                  linux_vfs="3"
         - name: eth1
           state: up
           type: ethernet
@@ -2564,6 +2622,10 @@ class TestNmstateNetConfig(base.TestCase):
               autoconf: False
               dhcp: False
               enabled: False
+          dispatch:
+              post-activation: |
+                  dpdk_vfs=""
+                  linux_vfs="3"
         """
 
         exp_bond_config = """

--- a/os_net_config/utils.py
+++ b/os_net_config/utils.py
@@ -218,6 +218,29 @@ def diff(filename, data):
     return not file_data == data
 
 
+def update_dpdk_map(ifname, driver):
+    noop = common.get_noop()
+    pci_address = get_pci_address(ifname, noop)
+    # pci address could be fetched before setting the override.
+    # Update the dpdk map with the PCI address, so that the succesive
+    # runs of os-net-config could fetch the pci address from the dpdk map
+    if pci_address and not noop:
+        mac_address = common.interface_mac(ifname)
+        _update_dpdk_map(ifname, pci_address, mac_address, driver)
+
+
+def get_dpdk_pci_address(ifname):
+    noop = common.get_noop()
+    # In case of DPDK devices, the pci address could be fetched using
+    # ethtool before setting the driverctl override.
+    # After setting the override, the pci address could be read back
+    # from the dpdk map.
+    pci_address = get_pci_address(ifname, noop)
+    if not pci_address:
+        pci_address = get_stored_pci_address(ifname, noop)
+    return pci_address
+
+
 def bind_dpdk_interfaces(ifname, driver, noop):
     if common.is_mellanox_interface(ifname) and 'vfio-pci' in driver:
         msg = ("For Mellanox NIC %s, the default driver vfio-pci "


### PR DESCRIPTION
When nmstate provider is used for NIC partitioning, the dispatch scripts shall be used to setup the driverctl override for the VFs that shall be attached to the dpdk port. This will ensure that the persistence of the override is taken care during reboot scenarios.

(cherry picked from commit 4a1adaefffd021f3a433504e0cfa2f5f449c98d5)
Signed-off-by: Abhiram R N <abhiramrn@gmail.com>