### PR TITLE
sriov: retain the VF count for interfaces

### DIFF
--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -45,6 +45,7 @@ from os_net_config import common
 from os_net_config import objects
 from os_net_config import utils
 
+
 logger = logging.getLogger(__name__)
 
 # Import the raw NetConfig object so we can call its methods
@@ -1393,9 +1394,14 @@ class NmstateNetConfig(os_net_config.NetConfig):
 
         data[Interface.TYPE] = InterfaceType.ETHERNET
         data[Ethernet.CONFIG_SUBTREE] = {}
+        int_data = self.iface_state(interface.name)
+        try:
+            cur_numvfs = int_data['ethernet']['sr-iov']['total-vfs']
+        except (KeyError, TypeError):
+            cur_numvfs = 0
         if utils.get_totalvfs(interface.name) > 0:
             data[Ethernet.CONFIG_SUBTREE][Ethernet.SRIOV_SUBTREE] = {
-                Ethernet.SRIOV.TOTAL_VFS: 0}
+                Ethernet.SRIOV.TOTAL_VFS: cur_numvfs}
 
         if interface.ethtool_opts:
             self.add_ethtool_config(interface.name, data,


### PR DESCRIPTION
Retain the sriov numvfs (if any) configured on the ethernet interface as it is. This is done so that the numvfs could be managed externally or separately in 2 different config yamls.


(cherry picked from commit 22b9a6570649d2c627e6a0f3d892ad13ce88789f)