### PR TITLE
route: adding the option to add route via next-hop-interface

### DIFF
--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -1168,9 +1168,15 @@ class NmstateNetConfig(os_net_config.NetConfig):
             if route.ip_netmask:
                 route_data[NMRoute.DESTINATION] = route.ip_netmask
             if route.next_hop:
-                route_data[NMRoute.NEXT_HOP_ADDRESS] = route.next_hop
-                route_data[NMRoute.NEXT_HOP_INTERFACE] = interface_name
+                if route.next_hop == "self":
+                    route_data[NMRoute.NEXT_HOP_INTERFACE] = interface_name
+                else:
+                    route_data[NMRoute.NEXT_HOP_ADDRESS] = route.next_hop
+                    route_data[NMRoute.NEXT_HOP_INTERFACE] = interface_name
                 if route.default:
+                    if route.next_hop == "self":
+                        msg = "self as next_hop allowed only with ip_netmask"
+                        raise os_net_config.ConfigurationError(msg)
                     if ":" in route.next_hop:
                         route_data[NMRoute.DESTINATION] = \
                             IPV6_DEFAULT_GATEWAY_DESTINATION

--- a/os_net_config/schema.yaml
+++ b/os_net_config/schema.yaml
@@ -121,7 +121,9 @@ definitions:
         type: string
         pattern: >-
           ^(?=^.{1,255}$)(?!.*\.\..*)(.{1,63}\.)+(.{0,63}\.?)|(?!\.)(?!.*\.\..*)(^.{1,63}$)|(^\.$)$
-
+    self_interface:
+        type: string
+        pattern: "^self$"
     list_of_domain_name_string_or_domain_name_string:
         oneOf:
           - type: array
@@ -169,7 +171,9 @@ definitions:
         oneOf:
         - properties:
             next_hop:
-                $ref: "#/definitions/ip_address_string_or_param"
+              oneOf:
+                - $ref: "#/definitions/ip_address_string_or_param"
+                - $ref: "#/definitions/self_interface"
             ip_netmask:
                 $ref: "#/definitions/ip_cidr_string_or_param"
             default:

--- a/os_net_config/tests/test_impl_nmstate.py
+++ b/os_net_config/tests/test_impl_nmstate.py
@@ -660,6 +660,46 @@ class TestNmstateNetConfig(base.TestCase):
         self.assertEqual(yaml.safe_load(expected_route_table),
                          self.get_route_config('em1'))
 
+    def test_network_with_route_via_device(self):
+        expected_route_table = """
+               - destination: 0.0.0.0/0
+                 metric: 10
+                 next-hop-interface: em1
+               - destination: 172.22.0.0/24
+                 metric: 100
+                 next-hop-address: 172.20.0.1
+                 next-hop-interface: em1
+           """
+        route1 = objects.Route("self", ip_netmask='0.0.0.0/0',
+                               route_options="metric 10")
+        route2 = objects.Route('172.20.0.1', '172.22.0.0/24',
+                               route_options="metric 100")
+        v4_addr = objects.Address('192.168.1.2/24')
+        interface = objects.Interface('em1', addresses=[v4_addr],
+                                      routes=[route1, route2])
+        self.provider.add_interface(interface)
+        self.assertEqual(yaml.safe_load(expected_route_table),
+                         self.get_route_config('em1'))
+
+    def test_network_with_ipv6_routes_via_device(self):
+        expected_route_table = """
+            - destination: ::/0
+              next-hop-interface: em1
+            - destination: beaf::/56
+              next-hop-address: beaf::1
+              next-hop-interface: em1
+        """
+        route4 = objects.Route('self', ip_netmask='::/0')
+        route5 = objects.Route('beaf::1', ip_netmask='beaf::/56')
+        v4_addr = objects.Address('192.168.1.2/24')
+        v6_addr = objects.Address('2001:abc:a::/64')
+        interface = objects.Interface('em1', addresses=[v4_addr, v6_addr],
+                                      routes=[route4, route5])
+
+        self.provider.add_interface(interface)
+        self.assertEqual(yaml.safe_load(expected_route_table),
+                         self.get_route_config('em1'))
+
     def test_network_with_ipv6_routes(self):
         expected_route_table = """
             - destination: ::/0


### PR DESCRIPTION
this PR will allow to use 'self' str in next_hop inorder to route though the device.
{"ip_netmask": "0.0.0.0/0", "next_hop": "self" }  or "routes": [{"ip_netmask": "::/0", "next_hop": "self" }]


(cherry picked from commit 47a3903fbb0740b09fe8fc6ab898c45aeff9c7d0)