### PR TITLE
logs: make logging precise and readable

### DIFF
--- a/os_net_config/__init__.py
+++ b/os_net_config/__init__.py
@@ -93,7 +93,7 @@ class NetConfig(object):
             self.del_sriov_vf(obj)
         else:
             obj_type = json.get("type")
-            logger.error(f'del_object not handled for {obj_type}')
+            logger.error("del_object not handled for %s", obj_type)
 
     def enable_migration():
         logger.info('Migration is not supported for this provider')
@@ -475,23 +475,23 @@ class NetConfig(object):
         Print a message and run a command with processutils
         in noop mode, this just prints a message.
         """
-        logger.info('%s%s' % (self.log_prefix, msg))
+        logger.info("%s%s", self.log_prefix, msg)
         if not self.noop:
             out, err = processutils.execute(cmd, *args, **kwargs)
             if err:
-                logger.error(f"stderr : {err}")
+                logger.error("stderr : %s", err)
             if out:
-                logger.debug(f"stdout : {out}")
+                logger.debug("stdout : %s", out)
 
     def write_config(self, filename, data, msg=None):
         msg = msg or "Writing config %s" % filename
-        logger.info('%s%s' % (self.log_prefix, msg))
+        logger.info("%s%s", self.log_prefix, msg)
         if not self.noop:
             utils.write_config(filename, data)
 
     def remove_config(self, filename, msg=None):
         msg = msg or "Removing config %s" % filename
-        logger.info('%s%s' % (self.log_prefix, msg))
+        logger.info("%s%s", self.log_prefix, msg)
         if not self.noop:
             os.remove(filename)
 

--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -184,7 +184,7 @@ def main(argv=sys.argv, main_logger=None):
     if not main_logger:
         main_logger = common.configure_logger(log_file=not opts.noop)
     common.logger_level(main_logger, opts.verbose, opts.debug)
-    main_logger.info(f"Using config file at: {opts.config_file}")
+    main_logger.info("Using config file at: %s", opts.config_file)
     iface_array = []
     configure_sriov = False
     sriovpf_bond_ovs_ports = []
@@ -209,27 +209,28 @@ def main(argv=sys.argv, main_logger=None):
 
     if opts.purge_provider:
         if opts.purge_provider == opts.provider:
-            main_logger.error('purge-provider and provider can\'t be the same')
+            main_logger.error("purge-provider and provider can't be the same")
             return 1
         try:
             purge_provider = load_provider(opts.purge_provider, opts.noop,
                                            opts.root_dir)
         except ImportError as e:
-            main_logger.error('cannot load purge provider %s: %s',
-                              opts.purge_provider, e)
+            main_logger.error(
+                "cannot load purge provider %s: %s", opts.purge_provider, e
+            )
             return 1
 
     # Read the interface mapping file, if it exists
     # This allows you to override the default network naming abstraction
     # mappings by specifying a specific nicN->name or nicN->MAC mapping
     if os.path.exists(opts.mapping_file):
-        main_logger.info(f"Using mapping file at: {opts.mapping_file}")
+        main_logger.info("Using mapping file at: %s", opts.mapping_file)
         with open(opts.mapping_file) as cf:
             iface_map = yaml.safe_load(cf.read())
             iface_mapping = iface_map.get("interface_mapping")
-            main_logger.debug(f"interface_mapping: {iface_mapping}")
+            main_logger.debug("interface_mapping: %s", iface_mapping)
             persist_mapping = opts.persist_mapping
-            main_logger.debug(f"persist_mapping: {persist_mapping}")
+            main_logger.debug("persist_mapping: %s", persist_mapping)
     else:
         main_logger.info("Not using any mapping file.")
         iface_mapping = None
@@ -252,16 +253,19 @@ def main(argv=sys.argv, main_logger=None):
                 if requested_nic in mapped_nics.values():
                     if found is True:  # Name matches alias and real NIC
                         # (return the mapped NIC, but warn of overlap).
-                        main_logger.warning(f"{requested_nic} overlaps with "
-                                            "real NIC name.")
+                        main_logger.warning(
+                            "%s overlaps with real NIC name.", requested_nic
+                        )
                     else:
                         reported_nics[requested_nic] = requested_nic
                         found = True
                 if not found:
                     retval = 1
             if reported_nics:
-                main_logger.debug("Interface mapping requested for interface: "
-                                  "%s" % reported_nics.keys())
+                main_logger.debug(
+                    "Interface mapping requested for interface: %s",
+                    reported_nics.keys(),
+                )
         else:
             main_logger.debug("Interface mapping requested for all interfaces")
             reported_nics = mapped_nics
@@ -276,17 +280,18 @@ def main(argv=sys.argv, main_logger=None):
         try:
             with open(opts.config_file) as cf:
                 iface_array = yaml.safe_load(cf.read()).get("network_config")
-                main_logger.debug(f"network_config: {iface_array}")
+                main_logger.debug("network_config: %s", iface_array)
         except IOError:
-            main_logger.error(f"Error reading file: {opts.config_file}")
+            main_logger.error("Error reading file: %s", opts.config_file)
             return 1
     else:
-        main_logger.error(f"No config file exists at: {opts.config_file}")
+        main_logger.error("No config file exists at: %s", opts.config_file)
         return 1
 
     if not isinstance(iface_array, list):
-        main_logger.error("No interfaces defined in config: "
-                          f"{opts.config_file}")
+        main_logger.error(
+            "No interfaces defined in config: %s", opts.config_file
+        )
         return 1
 
     for iface_json in iface_array:
@@ -297,10 +302,12 @@ def main(argv=sys.argv, main_logger=None):
     validation_errors = validator.validate_config(iface_array)
     if validation_errors:
         if opts.exit_on_validation_errors:
-            main_logger.error('\n'.join(validation_errors))
+            for e in validation_errors:
+                main_logger.error(e)
             return 1
         else:
-            main_logger.warning('\n'.join(validation_errors))
+            for e in validation_errors:
+                main_logger.warning(e)
 
     # Reset the DCB Config during rerun.
     # This is required to apply the new values and clear the old ones
@@ -394,14 +401,20 @@ def main(argv=sys.argv, main_logger=None):
 
         files_changed = provider.apply(cleanup=opts.cleanup,
                                        activate=not opts.no_activate)
-        logger.info('Succesfully applied the network configuration with '
-                    f'{opts.provider} provider')
+        logger.info(
+            "Succesfully applied the network configuration with "
+            "%s provider",
+            opts.provider,
+        )
     except Exception as e:
-        logger.error(f'***Failed to configure with {opts.provider} '
-                     f'provider***\n{e!r}')
+        logger.error(
+            "***Failed to configure with %s provider***\n%s",
+            opts.provider,
+            e
+        )
 
         if purge_provider:
-            logger.info(f'Rolling back to {opts.purge_provider}')
+            logger.info("Rolling back to %s", opts.purge_provider)
             # Rolling back to the earlier provider.
             purge_provider.roll_back_migration()
             migration_failed = True
@@ -413,7 +426,7 @@ def main(argv=sys.argv, main_logger=None):
         try:
             from os_net_config import dcb_config
         except ImportError as e:
-            logger.error(f'cannot apply DCB configuration: {e!r}')
+            logger.error("cannot apply DCB configuration: %s", e)
             return 1
 
         utils.configure_dcb_config_service()
@@ -421,19 +434,23 @@ def main(argv=sys.argv, main_logger=None):
         dcb_apply.apply()
 
     if purge_provider and migration_failed is False:
-        logger.info('Cleaning the residue files from '
-                    f'{opts.purge_provider} provider')
+        logger.info(
+            "Cleaning the residue files from %s provider", opts.purge_provider
+        )
         purge_provider.clean_migration()
     elif migration_failed:
-        logger.info('Migration Failed. Reverted back to '
-                    f'{opts.purge_provider} provider')
+        logger.info(
+            "Migration Failed. Reverted back to %s provider",
+            opts.purge_provider,
+        )
         return 1
 
     if opts.noop:
         if configure_sriov:
             files_changed.update(pf_files_changed)
         for location, data in files_changed.items():
-            print("File: %s\n" % location)
+            print("File:", location)
+            print()
             print(data)
             print("----")
 

--- a/os_net_config/impl_eni.py
+++ b/os_net_config/impl_eni.py
@@ -150,9 +150,9 @@ class ENINetConfig(os_net_config.NetConfig):
 
         :param interface: The Interface object to add.
         """
-        logger.info('adding interface: %s' % interface.name)
+        logger.info("adding interface: %s", interface.name)
         data = self._add_common(interface)
-        logger.debug('interface data: %s' % data)
+        logger.debug("interface data: %s", data)
         self.interfaces[interface.name] = data
         if interface.routes:
             self._add_routes(interface.name, interface.routes)
@@ -162,9 +162,9 @@ class ENINetConfig(os_net_config.NetConfig):
 
         :param bridge: The OvsBridge object to add.
         """
-        logger.info('adding bridge: %s' % bridge.name)
+        logger.info("adding bridge: %s", bridge.name)
         data = self._add_common(bridge)
-        logger.debug('bridge data: %s' % data)
+        logger.debug("bridge data: %s", data)
         self.bridges[bridge.name] = data
         if bridge.routes:
             self._add_routes(bridge.name, bridge.routes)
@@ -174,15 +174,15 @@ class ENINetConfig(os_net_config.NetConfig):
 
         :param vlan: The vlan object to add.
         """
-        logger.info('adding vlan: %s' % vlan.name)
+        logger.info("adding vlan: %s", vlan.name)
         data = self._add_common(vlan)
-        logger.debug('vlan data: %s' % data)
+        logger.debug("vlan data: %s", data)
         self.interfaces[vlan.name] = data
         if vlan.routes:
             self._add_routes(vlan.name, vlan.routes)
 
     def _add_routes(self, interface_name, routes=[]):
-        logger.info('adding custom route for interface: %s' % interface_name)
+        logger.info("adding custom route for interface: %s", interface_name)
         data = ""
         for route in routes:
             options = ""
@@ -197,7 +197,7 @@ class ENINetConfig(os_net_config.NetConfig):
             data += "down route del -net %s netmask %s gw %s%s\n" % (
                     str(rt.ip), str(rt.netmask), route.next_hop, options)
         self.routes[interface_name] = data
-        logger.debug('route data: %s' % self.routes[interface_name])
+        logger.debug("route data: %s", self.routes[interface_name])
 
     def apply(self, cleanup=False, activate=True):
         """Apply the network configuration.

--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -58,7 +58,7 @@ def remove_ifcfg_config(ifname):
     if re.match(r'[\w-]+$', ifname):
         ifcfg_file = ifcfg_config_path(ifname)
         if os.path.exists(ifcfg_file):
-            logger.info('removing existing ifcfg script for intf: %s' % ifname)
+            logger.info("removing existing ifcfg script for intf: %s", ifname)
             os.remove(ifcfg_file)
 
 
@@ -118,7 +118,7 @@ def stop_dhclient_process(interface):
     try:
         dhclient = dhclient_path()
     except RuntimeError as err:
-        logger.info('Exception when stopping dhclient: %s' % err)
+        logger.info("Exception when stopping dhclient: %s", err)
         return
 
     if os.path.exists(pid_file):
@@ -128,8 +128,9 @@ def stop_dhclient_process(interface):
         try:
             os.unlink(pid_file)
         except OSError as err:
-            logger.error('Could not remove dhclient pid file \'%s\': %s' %
-                         (pid_file, err))
+            logger.error(
+                "Could not remove dhclient pid file '%s': %s", pid_file, err
+            )
 
 
 class IfcfgNetConfig(os_net_config.NetConfig):
@@ -259,8 +260,8 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         """
 
         file_data = common.get_file_data(filename)
-        logger.debug(f'Original ifcfg file:\n{file_data}')
-        logger.debug(f'New ifcfg file:\n{new_data}')
+        logger.debug("Original ifcfg file:\n%s", file_data)
+        logger.debug("New ifcfg file:\n%s", new_data)
         file_values = self.parse_ifcfg(file_data)
         new_values = self.parse_ifcfg(new_data)
         restart_required = False
@@ -278,7 +279,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                     if change in new_values:
                         if (new_values[change].upper() == 'DHCP'):
                             restart_required = True
-                            logger.debug(f'DHCP on {change} requires restart')
+                            logger.debug("DHCP on %s requires restart", change)
                 else:
                     restart_required = True
         if not restart_required:
@@ -307,8 +308,8 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         previous_cfg = common.get_file_data(filename)
         file_values = self.parse_ifcfg(previous_cfg)
         data_values = self.parse_ifcfg(data)
-        logger.debug(f'File values:\n{file_values}')
-        logger.debug(f'Data values:\n{data_values}')
+        logger.debug("%s: File values:\n%s", dev_name, file_values)
+        logger.debug("%s: Data values:\n%s", dev_name, data_values)
         changes = self.enumerate_ifcfg_changes(file_values, data_values)
         resolv_conf = ''
         if 'DOMAIN' in changes or 'DNS1' in changes or 'DNS2' in changes:
@@ -338,8 +339,8 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         previous_cfg = common.get_file_data(filename)
         file_values = self.parse_ifcfg(previous_cfg)
         data_values = self.parse_ifcfg(data)
-        logger.debug(f'File values:\n{file_values}')
-        logger.debug(f'Data values:\n{data_values}')
+        logger.debug("%s: File values:\n%s", dev_name, file_values)
+        logger.debug("%s: Data values:\n%s", dev_name, data_values)
         changes = self.enumerate_ifcfg_changes(file_values, data_values)
         commands = []
         new_cidr = 0
@@ -389,8 +390,8 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         previous_cfg = common.get_file_data(filename)
         file_values = self.parse_ifcfg(previous_cfg)
         data_values = self.parse_ifcfg(data)
-        logger.debug(f'File values:\n{file_values}')
-        logger.debug(f'Data values:\n{data_values}')
+        logger.debug("%s: File values:\n%s", device_name, file_values)
+        logger.debug("%s: Data values:\n%s", device_name, data_values)
         changes = self.enumerate_ifcfg_changes(file_values, data_values)
         commands = []
 
@@ -781,7 +782,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         return data
 
     def _add_routes(self, interface_name, routes=[]):
-        logger.info('adding custom route for interface: %s' % interface_name)
+        logger.info("%s: adding custom route", interface_name)
         data = ""
         first_line = ""
         data6 = ""
@@ -816,8 +817,16 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                              interface_name, table, options)
         self.route_data[interface_name] = first_line + data
         self.route6_data[interface_name] = first_line6 + data6
-        logger.debug('route data: %s' % self.route_data[interface_name])
-        logger.debug('ipv6 route data: %s' % self.route6_data[interface_name])
+        logger.debug(
+            "%s: route data: %s",
+            interface_name,
+            self.route_data[interface_name],
+        )
+        logger.debug(
+            "%s: ipv6 route data: %s",
+            interface_name,
+            self.route6_data[interface_name],
+        )
 
     def _add_rules(self, interface, rules):
         """Add RouteRule objects to an interface.
@@ -825,7 +834,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         :param interface: the name of the interface to apply rules.
         :param rules: the list of rules to apply to the interface.
         """
-        logger.info('adding route rules for interface: %s' % interface)
+        logger.info("%s: adding route rules", interface)
         data = ""
         first_line = _IFCFG_FILE_HEADER
         for rule in rules:
@@ -833,15 +842,18 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                 data += "# %s\n" % rule.comment
             data += "%s\n" % rule.rule
         self.rule_data[interface] = first_line + data
-        logger.debug('rules for interface: %s' % self.rule_data[interface])
+        logger.debug(
+            "%s: rules for interface: %s", interface, self.rule_data[interface]
+        )
 
     def add_route_table(self, route_table):
         """Add a RouteTable object to the net config object.
 
         :param route_table: the RouteTable object to add.
         """
-        logger.info('adding route table: %s %s' % (route_table.table_id,
-                                                   route_table.name))
+        logger.info(
+            "adding route table: %s %s", route_table.table_id, route_table.name
+        )
         self.route_table_data[int(route_table.table_id)] = route_table.name
 
     def del_route_table(self, route_table):
@@ -852,9 +864,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param interface: The Interface object to add.
         """
-        logger.info('adding interface: %s' % interface.name)
+        logger.info("%s: adding interface", interface.name)
         data = self._add_common(interface)
-        logger.debug('interface data: %s' % data)
+        logger.debug("interface data: %s", data)
         self.interface_data[interface.name] = data
         if interface.routes:
             self._add_routes(interface.name, interface.routes)
@@ -862,8 +874,11 @@ class IfcfgNetConfig(os_net_config.NetConfig):
             self._add_rules(interface.name, interface.rules)
 
         if interface.renamed:
-            logger.info("Interface %s being renamed to %s"
-                        % (interface.hwname, interface.name))
+            logger.info(
+                "Interface %s being renamed to %s",
+                interface.hwname,
+                interface.name,
+            )
             self.renamed_interfaces[interface.hwname] = interface.name
 
     def del_interface(self, interface):
@@ -871,7 +886,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param interface: The Interface object to be deleted.
         """
-        logger.info(f'Deleting {interface}')
+        logger.info("%s: Deleting", interface)
         self._del_common(interface)
 
     def add_vlan(self, vlan):
@@ -879,9 +894,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param vlan: The vlan object to add.
         """
-        logger.info('adding vlan: %s' % vlan.name)
+        logger.info("%s: adding vlan", vlan.name)
         data = self._add_common(vlan)
-        logger.debug('vlan data: %s' % data)
+        logger.debug("vlan data: %s", data)
         self.vlan_data[vlan.name] = data
         if vlan.routes:
             self._add_routes(vlan.name, vlan.routes)
@@ -893,7 +908,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param vlan: The vlan object to be deleted.
         """
-        logger.info(f'Deleting vlan {vlan}')
+        logger.info("%s: Deleting vlan ", vlan)
         self._del_common(vlan)
 
     def add_ivs_interface(self, ivs_interface):
@@ -901,9 +916,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param ivs_interface: The ivs_interface object to add.
         """
-        logger.info('adding ivs_interface: %s' % ivs_interface.name)
+        logger.info("%s: adding ivs_interface", ivs_interface.name)
         data = self._add_common(ivs_interface)
-        logger.debug('ivs_interface data: %s' % data)
+        logger.debug("ivs_interface data: %s", data)
         self.ivsinterface_data[ivs_interface.name] = data
         if ivs_interface.routes:
             self._add_routes(ivs_interface.name, ivs_interface.routes)
@@ -916,9 +931,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         :param nfvswitch_internal: The nfvswitch_internal object to add.
         """
         iface_name = nfvswitch_internal.name
-        logger.info('adding nfvswitch_internal interface: %s' % iface_name)
+        logger.info("%s: adding nfvswitch_internal interface", iface_name)
         data = self._add_common(nfvswitch_internal)
-        logger.debug('nfvswitch_internal interface data: %s' % data)
+        logger.debug("nfvswitch_internal interface data: %s", data)
         self.nfvswitch_intiface_data[iface_name] = data
         if nfvswitch_internal.routes:
             self._add_routes(iface_name, nfvswitch_internal.routes)
@@ -930,9 +945,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param bridge: The OvsBridge object to add.
         """
-        logger.info('adding bridge: %s' % bridge.name)
+        logger.info("%s: adding bridge", bridge.name)
         data = self._add_common(bridge)
-        logger.debug('bridge data: %s' % data)
+        logger.debug("bridge data: %s", data)
         self.bridge_data[bridge.name] = data
         if bridge.routes:
             self._add_routes(bridge.name, bridge.routes)
@@ -944,7 +959,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param bridge: The OvsBridge object to be deleted
         """
-        logger.info(f'Deleting bridge: {bridge.name}')
+        logger.info("%s: Deleting bridge", bridge.name)
         self._del_common(bridge)
 
     def add_ovs_user_bridge(self, bridge):
@@ -952,9 +967,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param bridge: The OvsUserBridge object to add.
         """
-        logger.info('adding ovs user bridge: %s' % bridge.name)
+        logger.info("%s: adding ovs user bridge", bridge.name)
         data = self._add_common(bridge)
-        logger.debug('ovs user bridge data: %s' % data)
+        logger.debug("ovs user bridge data: %s", data)
         self.bridge_data[bridge.name] = data
         if bridge.routes:
             self._add_routes(bridge.name, bridge.routes)
@@ -966,7 +981,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param bridge: The OvsUserBridge object to be deleted.
         """
-        logger.info(f'Deleting ovs user bridge: {bridge.name}')
+        logger.info("%s: Deleting ovs user bridge", bridge.name)
         self._del_common(bridge)
 
     def add_linux_bridge(self, bridge):
@@ -974,9 +989,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param bridge: The LinuxBridge object to add.
         """
-        logger.info('adding linux bridge: %s' % bridge.name)
+        logger.info("%s: adding linux bridge", bridge.name)
         data = self._add_common(bridge)
-        logger.debug('bridge data: %s' % data)
+        logger.debug("bridge data: %s" % data)
         self.linuxbridge_data[bridge.name] = data
         if bridge.routes:
             self._add_routes(bridge.name, bridge.routes)
@@ -1010,9 +1025,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param bond: The OvsBond object to add.
         """
-        logger.info('adding bond: %s' % bond.name)
+        logger.info("%s: adding bond", bond.name)
         data = self._add_common(bond)
-        logger.debug('bond data: %s' % data)
+        logger.debug("bond data: %s", data)
         self.interface_data[bond.name] = data
         if bond.routes:
             self._add_routes(bond.name, bond.routes)
@@ -1024,7 +1039,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param bond: The OvsBond object to be deleted.
         """
-        logger.info(f'Deleting bond: {bond.name}')
+        logger.info("%s: Deleting bond", bond.name)
         self._del_common(bond)
 
     def add_linux_bond(self, bond):
@@ -1032,9 +1047,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param bond: The LinuxBond object to add.
         """
-        logger.info('adding linux bond: %s' % bond.name)
+        logger.info("%s: adding linux bond", bond.name)
         data = self._add_common(bond)
-        logger.debug('bond data: %s' % data)
+        logger.debug("bond data: %s", data)
         self.linuxbond_data[bond.name] = data
         if bond.routes:
             self._add_routes(bond.name, bond.routes)
@@ -1046,7 +1061,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param bond: The LinuxBond object to be deleted.
         """
-        logger.info(f'Deleting linux bond: {bond.name}')
+        logger.info("%s: Deleting linux bond", bond.name)
         self._del_common(bond)
 
     def add_linux_team(self, team):
@@ -1054,9 +1069,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param team: The LinuxTeam object to add.
         """
-        logger.info('adding linux team: %s' % team.name)
+        logger.info("%s: adding linux team", team.name)
         data = self._add_common(team)
-        logger.debug('team data: %s' % data)
+        logger.debug("team data: %s", data)
         self.linuxteam_data[team.name] = data
         if team.routes:
             self._add_routes(team.name, team.routes)
@@ -1068,9 +1083,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param tunnel: The OvsTunnel object to add.
         """
-        logger.info('adding ovs tunnel: %s' % tunnel.name)
+        logger.info("%s: adding ovs tunnel", tunnel.name)
         data = self._add_common(tunnel)
-        logger.debug('ovs tunnel data: %s' % data)
+        logger.debug("ovs tunnel data: %s", data)
         self.interface_data[tunnel.name] = data
 
     def add_ovs_patch_port(self, ovs_patch_port):
@@ -1078,9 +1093,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param ovs_patch_port: The OvsPatchPort object to add.
         """
-        logger.info('adding ovs patch port: %s' % ovs_patch_port.name)
+        logger.info("%s: adding ovs patch port", ovs_patch_port.name)
         data = self._add_common(ovs_patch_port)
-        logger.debug('ovs patch port data: %s' % data)
+        logger.debug("ovs patch port data: %s", data)
         self.interface_data[ovs_patch_port.name] = data
 
     def add_ib_interface(self, ib_interface):
@@ -1088,9 +1103,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param ib_interface: The InfiniBand interface object to add.
         """
-        logger.info('adding ib_interface: %s' % ib_interface.name)
+        logger.info("%s: adding ib_interface", ib_interface.name)
         data = self._add_common(ib_interface)
-        logger.debug('ib_interface data: %s' % data)
+        logger.debug("ib_interface data: %s", data)
         self.ib_interface_data[ib_interface.name] = data
         if ib_interface.routes:
             self._add_routes(ib_interface.name, ib_interface.routes)
@@ -1098,8 +1113,11 @@ class IfcfgNetConfig(os_net_config.NetConfig):
             self._add_rules(ib_interface.name, ib_interface.rules)
 
         if ib_interface.renamed:
-            logger.info("InfiniBand interface %s being renamed to %s"
-                        % (ib_interface.hwname, ib_interface.name))
+            logger.info(
+                "InfiniBand interface %s being renamed to %s",
+                ib_interface.hwname,
+                ib_interface.name,
+            )
             self.renamed_interfaces[ib_interface.hwname] = ib_interface.name
 
     def del_ib_interface(self, ib_interface):
@@ -1107,7 +1125,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param ib_interface: The InfiniBand interface object to be deleted
         """
-        logger.info(f'Deleting ib_interface: {ib_interface.name}')
+        logger.info("%s: Deleting ib_interface", ib_interface.name)
         self._del_common(ib_interface)
 
     def add_ib_child_interface(self, ib_child_interface):
@@ -1116,9 +1134,11 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         :param ib_child_interface: The InfiniBand child
          interface object to add.
         """
-        logger.info('adding ib_child_interface: %s' % ib_child_interface.name)
+        logger.info(
+            "%s: adding ib_child_interface: %s", ib_child_interface.name
+        )
         data = self._add_common(ib_child_interface)
-        logger.debug('ib_child_interface data: %s' % data)
+        logger.debug("ib_child_interface data: %s", data)
         self.ib_childs_data[ib_child_interface.name] = data
         if ib_child_interface.routes:
             self._add_routes(ib_child_interface.name,
@@ -1132,7 +1152,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         :param ib_child_interface: The InfiniBand child
          interface object to be deleted.
         """
-        logger.info(f'Deleting ib_child_interface: {ib_child_interface.name}')
+        logger.info("%s: Deleting ib_child_interface", ib_child_interface.name)
         self._del_common(ib_child_interface)
 
     def add_ovs_dpdk_port(self, ovs_dpdk_port):
@@ -1140,7 +1160,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param ovs_dpdk_port: The OvsDpdkPort object to add.
         """
-        logger.info('adding ovs dpdk port: %s' % ovs_dpdk_port.name)
+        logger.info("%s: adding ovs dpdk port", ovs_dpdk_port.name)
 
         # DPDK Port will have only one member of type Interface, validation
         # checks are added at the object creation stage.
@@ -1152,7 +1172,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
             remove_ifcfg_config(ifname)
 
         data = self._add_common(ovs_dpdk_port)
-        logger.debug('ovs dpdk port data: %s' % data)
+        logger.debug("ovs dpdk port data: %s", data)
         self.interface_data[ovs_dpdk_port.name] = data
 
         """Add an extra ifcfg entry for mellanox NICs,
@@ -1170,7 +1190,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param ovs_dpdk_port: The OvsDpdkPort object to be deleted.
         """
-        logger.info(f'Deleting ovs dpdk port: {ovs_dpdk_port.name}')
+        logger.info("%s: Deleting ovs dpdk port", ovs_dpdk_port.name)
         self._del_common(ovs_dpdk_port)
 
     def add_ovs_dpdk_bond(self, ovs_dpdk_bond):
@@ -1178,7 +1198,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param ovs_dpdk_bond: The OvsBond object to add.
         """
-        logger.info('adding ovs dpdk bond: %s' % ovs_dpdk_bond.name)
+        logger.info("%s: adding ovs dpdk bond", ovs_dpdk_bond.name)
 
         # Bind the dpdk interface
         for dpdk_port in ovs_dpdk_bond.members:
@@ -1190,7 +1210,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                 remove_ifcfg_config(ifname)
 
         data = self._add_common(ovs_dpdk_bond)
-        logger.debug('ovs dpdk bond data: %s' % data)
+        logger.debug("ovs dpdk bond data: %s", data)
         self.interface_data[ovs_dpdk_bond.name] = data
         if ovs_dpdk_bond.routes:
             self._add_routes(ovs_dpdk_bond.name, ovs_dpdk_bond.routes)
@@ -1214,7 +1234,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param ovs_dpdk_bond: The OvsBond object to be deleted.
         """
-        logger.info(f'Deleting ovs dpdk bond: {ovs_dpdk_bond.name}')
+        logger.info("%s: Deleting ovs dpdk bond", ovs_dpdk_bond.name)
         self._del_common(ovs_dpdk_bond)
 
     def add_sriov_pf(self, sriov_pf):
@@ -1222,9 +1242,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param sriov_pf: The SriovPF object to add
         """
-        logger.info('adding sriov pf: %s' % sriov_pf.name)
+        logger.info("%s: adding sriov pf", sriov_pf.name)
         data = self._add_common(sriov_pf)
-        logger.debug('sriov pf data: %s' % data)
+        logger.debug("sriov pf data: %s" % data)
         self.interface_data[sriov_pf.name] = data
         if sriov_pf.routes:
             self._add_routes(sriov_pf.name, sriov_pf.routes)
@@ -1236,7 +1256,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param sriov_pf: The SriovPF object to be deleted
         """
-        logger.info(f'Deleting sriov pf: {sriov_pf.name}')
+        logger.info("%s: Deleting sriov pf", sriov_pf.name)
         self.remove_sriov_pfs.append(sriov_pf.name)
 
     def add_sriov_vf(self, sriov_vf):
@@ -1244,10 +1264,14 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param sriov_vf: The SriovVF object to add
         """
-        logger.info('adding sriov vf: %s for pf: %s, vfid: %d'
-                    % (sriov_vf.name, sriov_vf.device, sriov_vf.vfid))
+        logger.info(
+            "%s-%d: adding sriov vf: %s",
+            sriov_vf.device,
+            sriov_vf.vfid,
+            sriov_vf.name,
+        )
         data = self._add_common(sriov_vf)
-        logger.debug('sriov vf data: %s' % data)
+        logger.debug("sriov vf data: %s", data)
         self.interface_data[sriov_vf.name] = data
         if sriov_vf.routes:
             self._add_routes(sriov_vf.name, sriov_vf.routes)
@@ -1259,8 +1283,12 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param sriov_vf: The SriovVF object to be deleted
         """
-        logger.info(f'Deleting sriov vf: {sriov_vf.name} for pf: '
-                    f'{sriov_vf.device}, vfid: {sriov_vf.vfid}')
+        logger.info(
+            "%s-%d: Deleting sriov vf: %s",
+            sriov_vf.device,
+            sriov_vf.vfid,
+            sriov_vf.name,
+        )
         self._del_common(sriov_vf)
 
     def add_vpp_interface(self, vpp_interface):
@@ -1277,8 +1305,11 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         if not self.noop:
             self.ifdown(vpp_interface.name)
             remove_ifcfg_config(vpp_interface.name)
-        logger.info('adding vpp interface: %s %s'
-                    % (vpp_interface.name, vpp_interface.pci_dev))
+        logger.info(
+            "%s: adding vpp interface: %s",
+            vpp_interface.name,
+            vpp_interface.pci_dev,
+        )
         self.vpp_interface_data[vpp_interface.name] = vpp_interface
 
     def add_vpp_bond(self, vpp_bond):
@@ -1286,7 +1317,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param vpp_bond: The VPPBond object to add
         """
-        logger.info('adding vpp bond: %s' % vpp_bond.name)
+        logger.info("%s: adding vpp bond", vpp_bond.name)
         self.vpp_bond_data[vpp_bond.name] = vpp_bond
 
     def add_contrail_vrouter(self, contrail_vrouter):
@@ -1295,14 +1326,15 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         :param contrail_vrouter:
            The ContrailVrouter object to add
         """
-        logger.info('adding contrail_vrouter interface: %s'
-                    % contrail_vrouter.name)
+        logger.info(
+            "%s: adding contrail_vrouter interface", contrail_vrouter.name
+        )
         ifnames = ",".join([m.name for m in contrail_vrouter.members])
         data = self._add_common(contrail_vrouter)
         data += "DEVICETYPE=vhost\n"
         data += "TYPE=kernel_mode\n"
         data += "BIND_INT=%s\n" % ifnames
-        logger.debug('contrail data: %s' % data)
+        logger.debug("contrail data: %s" % data)
         self.interface_data[contrail_vrouter.name] = data
         if contrail_vrouter.routes:
             self._add_routes(contrail_vrouter.name, contrail_vrouter.routes)
@@ -1315,8 +1347,10 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         :param contrail_vrouter_dpdk:
            The ContrailVrouterDpdk object to add
         """
-        logger.info('adding contrail vrouter dpdk interface: %s'
-                    % contrail_vrouter_dpdk.name)
+        logger.info(
+            "%s: adding contrail vrouter dpdk interface",
+            contrail_vrouter_dpdk.name,
+        )
         pci_string = ",".join(
             utils.translate_ifname_to_pci_address(bind_int.name, self.noop)
             for bind_int in contrail_vrouter_dpdk.members)
@@ -1331,7 +1365,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         data += "CPU_LIST=%s\n" % contrail_vrouter_dpdk.cpu_list
         if contrail_vrouter_dpdk.vlan_id:
             data += "VLAN_ID=%s\n" % contrail_vrouter_dpdk.vlan_id
-        logger.debug('contrail dpdk data: %s' % data)
+        logger.debug("contrail dpdk data: %s", data)
         self.interface_data[contrail_vrouter_dpdk.name] = data
         if contrail_vrouter_dpdk.routes:
             self._add_routes(contrail_vrouter_dpdk.name,
@@ -1346,8 +1380,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         :param linux_tap:
            The LinuxTap object to add
         """
-        logger.info('adding Linux TAP interface: %s'
-                    % linux_tap.name)
+        logger.info("%s: adding Linux TAP interface", linux_tap.name)
         data = self._add_common(linux_tap)
         data += "TYPE=Tap\n"
         self.interface_data[linux_tap.name] = data
@@ -1463,12 +1496,12 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         the same provider.
         """
         for iface in self.remove_iface:
-            logger.info(f'Purging {iface}')
+            logger.info("%s: Purging ", iface)
             self.purge(iface)
         if self.remove_sriov_pfs:
             sriov_config.reset_sriov_pfs()
         for sriov_dev in self.remove_sriov_pfs:
-            logger.info(f'Purging SR-IOV device {sriov_dev}')
+            logger.info("%s: Purging SR-IOV device", sriov_dev)
             self.purge(sriov_dev)
 
     def apply(self, cleanup=False, activate=True, config_rules_dns=True):
@@ -1546,8 +1579,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                     stop_dhclient_interfaces.append(interface_name)
 
             else:
-                logger.info('No changes required for interface: %s' %
-                            interface_name)
+                logger.info(
+                    "%s: No changes required for interface", interface_name
+                )
             if utils.diff(route_path, route_data):
                 update_files[route_path] = route_data
                 if interface_name not in restart_interfaces:
@@ -1582,8 +1616,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                         (interface_name, interface_path, iface_data))
                 update_files[interface_path] = iface_data
             else:
-                logger.info('No changes required for ivs interface: %s' %
-                            interface_name)
+                logger.info(
+                    "%s: No changes required for ivs interface", interface_name
+                )
             if utils.diff(route_path, route_data):
                 update_files[route_path] = route_data
                 if interface_name not in restart_interfaces:
@@ -1618,8 +1653,10 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                         (iface_name, iface_path, iface_data))
                 update_files[iface_path] = iface_data
             else:
-                logger.info('No changes required for nfvswitch interface: %s' %
-                            iface_name)
+                logger.info(
+                    "%s: No changes required for nfvswitch interface",
+                    iface_name,
+                )
             if utils.diff(route_path, route_data):
                 update_files[route_path] = route_data
                 if iface_name not in restart_interfaces:
@@ -1658,7 +1695,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                                           bridge_data))
                 update_files[bridge_path] = bridge_data
             else:
-                logger.info('No changes required for bridge: %s' % bridge_name)
+                logger.info("%s: No changes required for bridge", bridge_name)
             if utils.diff(br_route_path, route_data):
                 update_files[br_route_path] = route_data
                 if bridge_name not in restart_interfaces:
@@ -1697,7 +1734,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                                           bridge_data))
                 update_files[bridge_path] = bridge_data
             else:
-                logger.info('No changes required for bridge: %s' % bridge_name)
+                logger.info("%s: No changes required for bridge", bridge_name)
             if utils.diff(br_route_path, route_data):
                 update_files[br_route_path] = route_data
                 if bridge_name not in restart_bridges:
@@ -1736,8 +1773,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                         (team_name, team_path, team_data))
                 update_files[team_path] = team_data
             else:
-                logger.info('No changes required for linux team: %s' %
-                            team_name)
+                logger.info(
+                    "%s: No changes required for linux team", team_name
+                )
             if utils.diff(team_route_path, route_data):
                 update_files[team_route_path] = route_data
                 if team_name not in restart_linux_teams:
@@ -1781,8 +1819,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                         restart_linux_bonds.append(bond_name)
                         break
                 else:
-                    logger.info('No changes required for linux bond: %s' %
-                                bond_name)
+                    logger.info(
+                        "%s: No changes required for linux bond", bond_name
+                    )
             if utils.diff(bond_route_path, route_data):
                 update_files[bond_route_path] = route_data
                 if bond_name not in restart_linux_bonds:
@@ -1818,8 +1857,10 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                         (interface_name, interface_path, iface_data))
                 update_files[interface_path] = iface_data
             else:
-                logger.info('No changes required for InfiniBand iface: %s' %
-                            interface_name)
+                logger.info(
+                    "%s: No changes required for InfiniBand iface",
+                    interface_name,
+                )
             if utils.diff(route_path, route_data):
                 update_files[route_path] = route_data
                 if interface_name not in restart_interfaces:
@@ -1863,8 +1904,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                         (vlan_name, vlan_path, vlan_data))
                 update_files[vlan_path] = vlan_data
             else:
-                logger.info('No changes required for vlan interface: %s' %
-                            vlan_name)
+                logger.info(
+                    "%s: No changes required for vlan interface", vlan_name
+                )
             if utils.diff(vlan_route_path, route_data):
                 update_files[vlan_route_path] = route_data
                 if vlan_name not in restart_vlans:
@@ -1909,8 +1951,10 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                         (ib_child_name, ib_child_path, ib_child_data))
                 update_files[ib_child_path] = ib_child_data
             else:
-                logger.info('No changes required for the ib child interface: '
-                            '%s' % ib_child_name)
+                logger.info(
+                    "%s: No changes required for the ib child interface",
+                    ib_child_name,
+                )
             if utils.diff(ib_child_route_path, route_data):
                 update_files[ib_child_route_path] = route_data
                 if ib_child_name not in restart_ib_childs:
@@ -1939,8 +1983,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                 if ifcfg_file not in all_file_names:
                     interface_name = ifcfg_file[len(cleanup_pattern()) - 1:]
                     if interface_name != 'lo':
-                        logger.info('cleaning up interface: %s'
-                                    % interface_name)
+                        logger.info(
+                            "%s: cleaning up interface", interface_name
+                        )
                         self.ifdown(interface_name)
                         self.remove_config(ifcfg_file)
 
@@ -1950,16 +1995,20 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                                                         interface[1],
                                                         interface[2])
                 if commands:
-                    logger.debug('Running ip commands on interface: %s' %
-                                 interface[0])
+                    logger.debug(
+                        "%s: Running ip commands on interface", interface[0]
+                    )
                 for command in commands:
                     try:
                         args = command.split()
                         self.execute(f'Running ip {command}', ipcmd, *args)
                     except Exception as e:
-                        logger.warning(f"Error in 'ip {command}', "
-                                       f"restarting {interface[0]}:\n"
-                                       f"{str(e)}")
+                        logger.warning(
+                            "Error in 'ip %s', restarting %s:\n%s",
+                            command,
+                            interface[0],
+                            e,
+                        )
                         restart_interfaces.append(interface[0])
                         restart_interfaces.extend(
                             self.child_members(interface[0]))
@@ -1969,17 +2018,22 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                                                       interface[1],
                                                       interface[2])
                 if resolv_conf:
-                    logger.debug('Updating /etc/resolv.conf with config from '
-                                 f'interface {interface[0]}')
+                    logger.debug(
+                        "%s: Updating /etc/resolv.conf with config",
+                        interface[0],
+                    )
                     header = '# Generated by os-net-config\n'
                     resolv_conf = header + resolv_conf
                     try:
                         with open('/etc/resolv.conf', 'w') as f:
                             f.write(resolv_conf)
                     except Exception as e:
-                        logger.warning("Error writing to /etc/resolv.conf "
-                                       f"restarting {interface[0]}:\n"
-                                       f"{str(e)}")
+                        logger.warning(
+                            "Error writing to /etc/resolv.conf, "
+                            "restarting %s\n%s",
+                            interface[0],
+                            e,
+                        )
                         restart_interfaces.append(interface[0])
                         restart_interfaces.extend(
                             self.child_members(interface[0]))
@@ -1989,8 +2043,10 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                                                       interface[1],
                                                       interface[2])
                 if commands:
-                    logger.debug('Running ethtool commands on interface: %s' %
-                                 interface[0])
+                    logger.debug(
+                        "%s: Running ethtool commands on interface",
+                        interface[0],
+                    )
                 for command in commands:
                     try:
                         args = command.split()
@@ -2000,9 +2056,12 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                         self.execute('Running ethtool %s' % command,
                                      ethtoolcmd, *args)
                     except Exception as e:
-                        logger.warning("Error in 'ethtool %s', restarting %s:\
-                                       \n%s)" %
-                                       (command, interface[0], str(e)))
+                        logger.warning(
+                            "Error in 'ethtool %s', restarting %s:\n%s)",
+                            command,
+                            interface[0],
+                            e,
+                        )
                         restart_interfaces.append(interface[0])
                         restart_interfaces.extend(
                             self.child_members(interface[0]))
@@ -2013,14 +2072,20 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                                                         bridge[1],
                                                         bridge[2])
                 if commands:
-                    logger.debug(f'Running ip commands on bridge: {bridge[0]}')
+                    logger.debug(
+                        "%s: Running ip commands on bridge", bridge[0]
+                    )
                 for command in commands:
                     try:
                         args = command.split()
                         self.execute('Running ip %s' % command, ipcmd, *args)
                     except Exception as e:
-                        logger.warning("Error in 'ip %s', restarting %s:\n%s" %
-                                       (command, bridge[0], str(e)))
+                        logger.warning(
+                            "Error in 'ip %s', restarting %s:\n%s",
+                            command,
+                            bridge[0],
+                            e,
+                        )
                         restart_bridges.append(bridge[0])
                         restart_interfaces.extend(
                             self.child_members(bridge[0]))
@@ -2030,24 +2095,26 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                                                       bridge[1],
                                                       bridge[2])
                 if resolv_conf:
-                    logger.debug('Updating /etc/resolv.conf with config from '
-                                 f'bridge {bridge[0]}')
+                    logger.debug("%s: Updating /etc/resolv.conf", bridge[0])
                     header = '# Generated by os-net-config\n'
                     resolv_conf = header + resolv_conf
                     try:
                         with open('/etc/resolv.conf', 'w') as f:
                             f.write(resolv_conf)
                     except Exception as e:
-                        logger.warning("Error writing to /etc/resolv.conf "
-                                       f"restarting {bridge[0]}:\n"
-                                       f"{str(e)}")
+                        logger.warning(
+                            "Error writing to /etc/resolv.conf, restarting "
+                            "%s:\n%s",
+                            bridge[0],
+                            e,
+                        )
                         restart_bridges.append(bridge[0])
                         restart_bridges.extend(
                             self.child_members(bridge[0]))
                         break
 
             for interface in apply_routes:
-                logger.debug('Applying routes for interface %s' % interface[0])
+                logger.debug("%s: Applying routes for interface", interface[0])
                 filename = self.root_dir + route_config_path(interface[0])
                 commands = self.iproute2_route_commands(filename, interface[1])
                 for command in commands:
@@ -2057,15 +2124,19 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                             self.execute('Running ip %s' % command, ipcmd,
                                          *args)
                     except Exception as e:
-                        logger.warning("Error in 'ip %s', restarting %s:\n%s" %
-                                       (command, interface[0], str(e)))
+                        logger.warning(
+                            "Error in 'ip %s', restarting %s:\n%s",
+                            command,
+                            interface[0],
+                            e,
+                        )
                         restart_interfaces.append(interface[0])
                         restart_interfaces.extend(
                             self.child_members(interface[0]))
                         break
 
             for interface in apply_rules:
-                logger.debug('Applying rules for interface %s' % interface[0])
+                logger.debug("%s: Applying rules for interface", interface[0])
                 filename = self.root_dir + route_rule_config_path(interface[0])
                 commands = self.iproute2_rule_commands(filename, interface[1])
                 for command in commands:
@@ -2075,8 +2146,12 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                             self.execute('Running ip %s' % command, ipcmd,
                                          *args)
                     except Exception as e:
-                        logger.warning("Error in 'ip %s', restarting %s:\n%s" %
-                                       (command, interface[0], str(e)))
+                        logger.warning(
+                            "Error in 'ip %s', restarting %s:\n%s",
+                            command,
+                            interface[0],
+                            e,
+                        )
                         restart_interfaces.append(interface[0])
                         restart_interfaces.extend(
                             self.child_members(interface[0]))
@@ -2156,8 +2231,9 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
             # If dhclient is running and dhcp not set, stop dhclient
             for interface in stop_dhclient_interfaces:
-                logger.debug("Calling stop_dhclient_interfaces() for %s" %
-                             interface)
+                logger.debug(
+                    "%s: Calling stop_dhclient_interfaces()", interface
+                )
                 if not self.noop:
                     stop_dhclient_process(interface)
 
@@ -2177,20 +2253,24 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                                 ignore_err=True)
 
             if ivs_uplinks or ivs_interfaces:
-                logger.info("Attach to ivs with "
-                            "uplinks: %s, "
-                            "interfaces: %s" %
-                            (ivs_uplinks, ivs_interfaces))
+                logger.info(
+                    "Attach to ivs with uplinks: %s, interfaces: %s",
+                    ivs_uplinks,
+                    ivs_interfaces,
+                )
                 for ivs_uplink in ivs_uplinks:
                     self.ifup(ivs_uplink)
                 for ivs_interface in ivs_interfaces:
                     self.ifup(ivs_interface)
 
             if nfvswitch_interfaces or nfvswitch_internal_ifaces:
-                logger.info("Attach to nfvswitch with "
-                            "interfaces: %s, "
-                            "internal interfaces: %s" %
-                            (nfvswitch_interfaces, nfvswitch_internal_ifaces))
+                logger.info(
+                    "Attach to nfvswitch with "
+                    "interfaces: %s, "
+                    "internal interfaces: %s",
+                    nfvswitch_interfaces,
+                    nfvswitch_internal_ifaces,
+                )
                 for nfvswitch_interface in nfvswitch_interfaces:
                     self.ifup(nfvswitch_interface)
                 for nfvswitch_internal in nfvswitch_internal_ifaces:
@@ -2231,22 +2311,22 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         if os.path.exists(ifcfg_file):
             new_ifcfg_file = os.path.join(PURGE_IFCFG_FILES,
                                           f'ifcfg-{iface_name}')
-            logger.info(f'Moving {ifcfg_file} to {new_ifcfg_file}')
+            logger.info("Moving %s -> %s", ifcfg_file, new_ifcfg_file)
             shutil.move(ifcfg_file, new_ifcfg_file)
         if os.path.exists(route_file):
             new_route_file = os.path.join(PURGE_IFCFG_FILES,
                                           f'route-{iface_name}')
-            logger.info(f'Moving {route_file} to {new_route_file}')
+            logger.info("Moving %s -> %s", route_file, new_route_file)
             shutil.move(route_file, new_route_file)
         if os.path.exists(route6_file):
             new_route6_file = os.path.join(PURGE_IFCFG_FILES,
                                            f'route6-{iface_name}')
-            logger.info(f'Moving {route6_file} to {new_route6_file}')
+            logger.info("Moving %s - %s", route6_file, new_route6_file)
             shutil.move(route6_file, new_route6_file)
         if os.path.exists(rule_file):
             new_rule_file = os.path.join(PURGE_IFCFG_FILES,
                                          f'rule-{iface_name}')
-            logger.info(f'Moving {rule_file} to {new_rule_file}')
+            logger.info("Moving %s -> %s", rule_file, new_rule_file)
             shutil.move(rule_file, new_rule_file)
 
     def roll_back_migration(self):
@@ -2289,7 +2369,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                 device_name = file[len('route6-'):]
 
             if device_name:
-                logger.info(f'Bringing up device {device_name}')
+                logger.info("%s: Bringing up device", device_name)
                 self.ifup(device_name)
 
     def purge(self, iface_name):
@@ -2298,9 +2378,10 @@ class IfcfgNetConfig(os_net_config.NetConfig):
             with open(ifcfg_file, 'r') as f:
                 file_content = f.read()
             if _IFCFG_FILE_HEADER in file_content:
-                logger.info(f'Calling ifdown {iface_name}')
+                logger.info("%s: Bringing down", iface_name)
                 self.ifdown(iface_name)
                 self.move_ifcfg(iface_name)
             else:
-                logger.info(f'Device {iface_name} is not managed by ifcfg '
-                            'provider')
+                logger.info(
+                    "%s: Device is not managed by ifcfg provider", iface_name
+                )

--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -196,7 +196,7 @@ def _add_sub_tree(data, subtree):
     :returns: The tip of the nested dict created
     """
     if data is None:
-        msg = 'Subtree can\'t be created on None Types'
+        msg = "Subtree can't be created on None Types"
         raise os_net_config.ConfigurationError(msg)
     config = data
     if subtree:
@@ -357,8 +357,9 @@ class NmstateNetConfig(os_net_config.NetConfig):
         # only for NIC Partitioning use cases.
         self.need_vf_config = False
         self.initial_state = netinfo.show_running_config()
-        self.__dump_key_config(self.initial_state,
-                               msg="Initial network settings")
+        self.__dump_key_config(
+            self.initial_state, msg='Initial network settings'
+        )
         logger.info('nmstate net config provider created.')
 
     def reload_nm(self):
@@ -395,13 +396,13 @@ class NmstateNetConfig(os_net_config.NetConfig):
         cfg_dump = yaml.dump(config, default_flow_style=False,
                              allow_unicode=True, encoding=None)
         logger.debug("----------------------------")
-        logger.debug(f"{msg}\n{cfg_dump}")
+        logger.debug("%s\n%s", msg, cfg_dump)
 
     def __dump_key_config(self, config, msg="Applying config"):
         cfg_dump = yaml.dump(config, default_flow_style=False,
                              allow_unicode=True, encoding=None)
         logger.info("----------------------------")
-        logger.info(f"{msg}\n{cfg_dump}")
+        logger.info("%s\n%s", msg, cfg_dump)
 
     def get_vf_config(self, sriov_vf):
         """Create the nmstate schema for the given VF
@@ -411,12 +412,6 @@ class NmstateNetConfig(os_net_config.NetConfig):
         :param sriov_vf: The SriovVF object that has the VF config
         :returns: The VF config in nmstate schema format
         """
-        logger.info(f'VF Config for vfid {sriov_vf.vfid} '
-                    f'device {sriov_vf.device} Trust={sriov_vf.trust} '
-                    f'vlan={sriov_vf.vlan_id} Qos={sriov_vf.qos}'
-                    f'Max Rate= {sriov_vf.max_tx_rate} '
-                    f'Min Rate={sriov_vf.min_tx_rate}'
-                    f'Spoofcheck={sriov_vf.spoofcheck}')
         vf_config = {}
         vf_config[Ethernet.SRIOV.VFS.ID] = sriov_vf.vfid
         if sriov_vf.macaddr:
@@ -453,18 +448,20 @@ class NmstateNetConfig(os_net_config.NetConfig):
             configured, while attempting a VF configuration
         """
         if sriov_vf.device in self.sriov_vf_data:
-            logger.info(f'Updating the VF data for VF: {sriov_vf.vfid} '
-                        f'Device: {sriov_vf.device} Trust: {sriov_vf.trust} '
-                        f'Spoofcheck: {sriov_vf.spoofcheck} '
-                        f'Vlan: {sriov_vf.vlan_id} Qos: {sriov_vf.qos} '
-                        f'Min Rate: {sriov_vf.min_tx_rate} '
-                        f'Max Rate: {sriov_vf.max_tx_rate}')
+            logger.info(
+                "%s-%d: Updating VF, Trust: %s "
+                "Spoofcheck: %s Vlan: %d Qos: %d "
+                "Min Rate: %d Max Rate: %d",
+                sriov_vf.device, sriov_vf.vfid,
+                sriov_vf.trust, sriov_vf.spoofcheck,
+                sriov_vf.vlan_id, sriov_vf.qos,
+                sriov_vf.min_tx_rate, sriov_vf.max_tx_rate
+            )
             vf_config = self.get_vf_config(sriov_vf)
             self.sriov_vf_data[sriov_vf.device][sriov_vf.vfid] = vf_config
             self.add_vf_driver_override(sriov_vf)
         else:
-            msg = (f'SR-IOV PF is not configured on {sriov_vf.device}, '
-                   f'while the VF {sriov_vf.vfid} is used')
+            msg = f"{sriov_vf.device}-{sriov_vf.vfid}: PF is not configured"
             raise objects.InvalidConfigException(msg)
 
     def apply_pf_config(self, activate):
@@ -492,12 +489,12 @@ class NmstateNetConfig(os_net_config.NetConfig):
             cur_state = self.iface_state(pf_name)
             if not is_dict_subset(cur_state, pf_state):
                 if not self.noop and activate:
-                    logger.debug(f'{pf_name}: Applying the PF config')
+                    logger.debug("%s: Applying the PF config", pf_name)
                     self.nmstate_apply(self.set_ifaces([pf_state]),
                                        verify=True)
                     updated_pfs.append(pf_name)
             else:
-                logger.info(f'{pf_name}: No changes required for PF')
+                logger.info("%s: No changes required for PF", pf_name)
         self.need_pf_config = False
         return updated_pfs
 
@@ -566,14 +563,17 @@ class NmstateNetConfig(os_net_config.NetConfig):
 
                 if not is_dict_subset(cur_state, pf_state):
                     if not self.noop and activate:
-                        logger.debug(f'{pf_state["name"]}: Applying the VF '
-                                     'parameters')
+                        logger.debug(
+                            "%s: Applying the VF parameters",
+                            pf_state["name"],
+                        )
                         self.nmstate_apply(self.set_ifaces([pf_state]),
                                            verify=True)
                         updated_pfs.append(pf_state["name"])
                 else:
-                    logger.info(f'{pf_state["name"]}: '
-                                'No changes required for VFs')
+                    logger.info(
+                        "%s: No changes required for VFs", pf_state["name"]
+                    )
         # Clear the flag once all the VFs are configured
         self.need_vf_config = False
         return updated_pfs
@@ -642,17 +642,21 @@ class NmstateNetConfig(os_net_config.NetConfig):
                                     custom_tables[id_name[0]] = id_name[1]
                                     data += f"{line}\n"
         if custom_tables:
-            logger.debug(f"Existing route tables: {custom_tables}")
+            logger.debug("Present state of route tables: %s", custom_tables)
         for id in sorted(route_tables):
             if str(id) in res_ids:
-                message = f"Table {route_tables[id]}({id}) conflicts with " \
-                          f"reserved table "\
-                          f"{res_names[res_ids.index(str(id))]}({id})"
+                message = (
+                    f"Table {route_tables[id]}({id}) conflicts with "
+                    f"reserved table "
+                    f"{res_names[res_ids.index(str(id))]}({id})"
+                )
                 raise os_net_config.ConfigurationError(message)
             elif route_tables[id] in res_names:
-                message = f"Table {route_tables[id]}({id}) conflicts with "\
-                          f"reserved table {route_tables[id]}" \
-                          f"({res_ids[res_names.index(route_tables[id])]})"
+                message = (
+                    f"Table {route_tables[id]}({id}) conflicts with "
+                    f"reserved table {route_tables[id]}"
+                    f"({res_ids[res_names.index(route_tables[id])]})"
+                )
                 raise os_net_config.ConfigurationError(message)
             else:
                 data += f"{id}\t{route_tables[id]}     "\
@@ -672,11 +676,10 @@ class NmstateNetConfig(os_net_config.NetConfig):
             for iface in ifaces:
                 if iface[Interface.NAME] != name:
                     continue
-                self.__dump_config(iface, msg=f"Running config for {name}")
+                self.__dump_config(iface, msg=f"{name}: Present state")
                 return iface
         else:
-            self.__dump_config(ifaces,
-                               msg=f"Running config for all interfaces")
+            self.__dump_config(ifaces, msg="Present state for all interfaces")
             return ifaces
 
     def cleanup_all_ifaces(self, exclude_nics=[]):
@@ -688,6 +691,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
         :param exclude_nics: The list of nics that shall not be removed
         """
 
+        logger.info("cleaning up all network configs...")
         exclude_nics.extend(['lo'])
         ifaces = netinfo.show_running_config()[Interface.KEY]
 
@@ -695,12 +699,13 @@ class NmstateNetConfig(os_net_config.NetConfig):
             if Interface.NAME in iface and \
                iface[Interface.NAME] not in exclude_nics:
                 if iface[Interface.STATE] == InterfaceState.IGNORE:
-                    logger.info(f"Skip cleaning {iface[Interface.NAME]}")
+                    logger.info("%s: Skip cleaning", iface[Interface.NAME])
                     continue
                 iface[Interface.STATE] = InterfaceState.ABSENT
                 state = {Interface.KEY: [iface]}
                 self.__dump_key_config(
-                    iface, msg=f"Cleaning up {iface[Interface.NAME]}")
+                    iface, msg=f"{iface[Interface.NAME]}: Cleaning up"
+                )
                 if not self.noop:
                     netapplier.apply(state, verify_change=True)
 
@@ -717,11 +722,12 @@ class NmstateNetConfig(os_net_config.NetConfig):
         if name != "":
             route = list(x for x in routes if x[
                 NMRoute.NEXT_HOP_INTERFACE] == name)
-            self.__dump_config(route,
-                               msg=f'Running route config for {name}')
+            if self.noop:
+                self.__dump_config(route, msg=f"{name}: Present route config")
             return route
         else:
-            self.__dump_config(routes, msg=f'Running routes config')
+            if self.noop:
+                self.__dump_config(routes, msg="Present route config")
             return routes
 
     def rule_state(self):
@@ -734,7 +740,8 @@ class NmstateNetConfig(os_net_config.NetConfig):
 
         rules = netinfo.show_running_config()[
             NMRouteRule.KEY][NMRouteRule.CONFIG]
-        self.__dump_config(rules, msg=f'List of IP rules running config')
+        if self.noop:
+            self.__dump_config(rules, msg="Present IP Rules")
         return rules
 
     def set_ifaces(self, iface_data):
@@ -744,7 +751,8 @@ class NmstateNetConfig(os_net_config.NetConfig):
         :return Interface state
         """
         state = {Interface.KEY: iface_data}
-        self.__dump_config(state, msg=f"Prepared interface config")
+        if self.noop:
+            self.__dump_config(state, msg="Prepared interface config")
         return state
 
     def set_dns(self):
@@ -753,10 +761,10 @@ class NmstateNetConfig(os_net_config.NetConfig):
         :param dns_data:  config json
         :return dns config
         """
-
         state = {DNS.KEY: {DNS.CONFIG: {DNS.SERVER: self.dns_data['server'],
                                         DNS.SEARCH: self.dns_data['domain']}}}
-        self.__dump_config(state, msg=f"Prepared DNS")
+        if self.noop:
+            self.__dump_config(state, msg="Prepared DNS")
         return state
 
     def set_routes(self, route_data):
@@ -767,7 +775,8 @@ class NmstateNetConfig(os_net_config.NetConfig):
         """
 
         state = {NMRoute.KEY: {NMRoute.CONFIG: route_data}}
-        self.__dump_config(state, msg=f'Prepared routes')
+        if self.noop:
+            self.__dump_config(state, msg="Prepared routes")
         return state
 
     def set_rules(self, rule_data):
@@ -777,7 +786,8 @@ class NmstateNetConfig(os_net_config.NetConfig):
         :return route rule states
         """
         state = {NMRouteRule.KEY: {NMRouteRule.CONFIG: rule_data}}
-        self.__dump_config(state, msg=f'Prepared rules are')
+        if self.noop:
+            self.__dump_config(state, msg="Prepared rules are")
         return state
 
     def nmstate_apply(self, new_state, verify=True):
@@ -786,19 +796,24 @@ class NmstateNetConfig(os_net_config.NetConfig):
         :param new_state: desired network config json
         :param verify: boolean that determines if config will be verified
         """
-        self.__dump_key_config(new_state,
-                               msg=f'Applying the config with nmstate')
+        self.__dump_key_config(
+            new_state, msg="Applying the config with nmstate"
+        )
         if not self.noop:
             try:
                 netapplier.apply(new_state, verify_change=verify)
             except error.NmstateVerificationError as exc:
-                logger.error(f'**** Verification Error *****')
-                logger.error(f'Error seen while applying the nmstate '
-                             f'templates {exc}')
+                logger.error("**** Verification Error *****")
+                logger.error(
+                    "Error seen while applying the nmstate templates %s",
+                    exc,
+                )
                 self.errors.append(exc)
             except error.NmstateError as exc:
-                logger.error(f'Error seen while applying the nmstate '
-                             f'templates {exc}')
+                logger.error(
+                    "Error seen while applying the nmstate templates %s",
+                    exc,
+                )
                 self.errors.append(exc)
 
     def generate_routes(self, interface_name):
@@ -812,10 +827,12 @@ class NmstateNetConfig(os_net_config.NetConfig):
 
         del_routes = []
         clean_routes = False
-        self.__dump_config(curr_routes,
-                           msg=f'Present route config for {interface_name}')
-        self.__dump_config(add_routes,
-                           msg=f'Desired route config for {interface_name}')
+        self.__dump_config(
+            curr_routes, msg=f"{interface_name}: Present route config"
+        )
+        self.__dump_config(
+            add_routes, msg=f"{interface_name}: Desired route config"
+        )
 
         for c_route in curr_routes:
             if c_route not in add_routes:
@@ -825,7 +842,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
             for c_route in curr_routes:
                 c_route[NMRoute.STATE] = NMRoute.STATE_ABSENT
                 del_routes.append(c_route)
-                logger.info(f'Prepare to remove route - {c_route}')
+                logger.info("Prepare to remove route - %s", c_route)
         return add_routes, del_routes
 
     def generate_rules(self):
@@ -838,11 +855,9 @@ class NmstateNetConfig(os_net_config.NetConfig):
         del_rules = []
         clear_rules = False
 
-        self.__dump_config(curr_rules,
-                           msg=f'Present set of ip rules')
+        self.__dump_config(curr_rules, msg="Present set of ip rules")
 
-        self.__dump_config(add_rules,
-                           msg=f'Desired ip rules')
+        self.__dump_config(add_rules, msg="Desired ip rules")
 
         for c_rule in curr_rules:
             if c_rule not in add_rules:
@@ -852,7 +867,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
             for c_rule in curr_rules:
                 c_rule[NMRouteRule.STATE] = NMRouteRule.STATE_ABSENT
                 del_rules.append(c_rule)
-                logger.info(f'Prepare to remove rule - {c_rule}')
+                logger.info("Prepare to remove rule - %s", c_rule)
         return add_rules, del_rules
 
     def interface_mac(self, iface):
@@ -897,8 +912,6 @@ class NmstateNetConfig(os_net_config.NetConfig):
             else:
                 port = {'name': member}
                 bps.append(port)
-
-        logger.debug(f"Adding ovs ports {bps}")
         return bps
 
     def add_ethtool_subtree(self, data, sub_config, command):
@@ -918,8 +931,10 @@ class NmstateNetConfig(os_net_config.NetConfig):
             elif (sub_config['sub-options'] == 'copy'):
                 config[command[index]] = value
             else:
-                msg = f'Unhandled ethtool option {command[index]} for '\
-                      f'command {command}.'
+                msg = (
+                    f"Unhandled ethtool option {command[index]} for "
+                    f"command {command}."
+                )
                 raise os_net_config.ConfigurationError(msg)
 
     def add_ethtool_config(self, iface_name, data, ethtool_options):
@@ -1007,21 +1022,28 @@ class NmstateNetConfig(os_net_config.NetConfig):
                 # are present in ethtool_opts.
                 command = ethtool_opts.split()
                 if len(command) < 4:
-                    msg = f"Ethtool options {command} is incomplete"
+                    msg = (
+                        f"{iface_name}: Ethtool options {command} "
+                        "is incomplete"
+                    )
                     raise os_net_config.ConfigurationError(msg)
 
                 option = command[0]
                 accepted_dev_names = ['${DEVICE}', '$DEVICE', iface_name]
                 if command[1] not in accepted_dev_names:
-                    msg = f'Skipping {ethtool_opts} due to incorrect device '\
-                          f'name present for interface {iface_name}'
+                    msg = (
+                        f"{iface_name}: Incorrect dev name found in "
+                        "{ethtool_opts}"
+                    )
                     raise os_net_config.ConfigurationError(msg)
                 if option in ethtool_map.keys():
                     self.add_ethtool_subtree(data, ethtool_map[option],
                                              command)
                 else:
-                    msg = f'Unhandled ethtool_opts {ethtool_opts} for device'\
-                          f' {iface_name}. Option {option} is not supported.'
+                    msg = (
+                        f"{iface_name}: Unhandled ethtool_opts "
+                        f"{ethtool_opts} Option {option} is not supported."
+                    )
                     raise os_net_config.ConfigurationError(msg)
             else:
                 command_str = '-s ${DEVICE} ' + ethtool_opts
@@ -1035,14 +1057,14 @@ class NmstateNetConfig(os_net_config.NetConfig):
                       Interface.TYPE: obj_type,
                       Interface.STATE: InterfaceState.ABSENT}
         absent_state_config = {Interface.KEY: [iface_data]}
-        self.__dump_key_config(absent_state_config, msg=f"Cleaning {name}")
+        self.__dump_key_config(absent_state_config, msg=f"{name}: Cleaning")
         netapplier.apply(absent_state_config, verify_change=True)
 
     def enable_migration(self):
         """Enable migration from other providers to nmstate"""
         self.reload_nm()
         self.migration_enabled = True
-        logger.info('Migration is enabled for nmstate provider.')
+        logger.info("nmstate: Migration is enabled.")
 
     def _add_common(self, base_opt):
         """Add common atrributes of the interface
@@ -1098,7 +1120,6 @@ class NmstateNetConfig(os_net_config.NetConfig):
             if not base_opt.hotplug:
                 logger.info('Using NetworkManager, hotplug is always set to'
                             'true. Deprecating it from next release')
-
         if base_opt.mtu:
             data[Interface.MTU] = base_opt.mtu
         if base_opt.addresses:
@@ -1152,8 +1173,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
         """
 
         routes_data = []
-        logger.info(f'adding custom route for interface: {interface_name}')
-
+        logger.info("%s: adding custom route", interface_name)
         for route in routes:
             route_data = {}
             if route.route_options:
@@ -1191,21 +1211,29 @@ class NmstateNetConfig(os_net_config.NetConfig):
                     route_data[NMRoute.TABLE_ID] = \
                         rt_tables[route.route_table]
                 else:
-                    logger.error(f'Unidentified mapping for route_table '
-                                 '{route.route_table}')
+                    logger.error(
+                        "%s: Unidentified mapping for route_table %s",
+                        interface_name,
+                        route.route_table,
+                    )
 
             routes_data.append(route_data)
 
         self.route_data[interface_name] = routes_data
-        logger.debug(f'route data: {self.route_data[interface_name]}')
+        self.__dump_config(
+            routes_data, msg=f"{interface_name}: Prepared route config"
+        )
 
     def add_route_table(self, route_table):
         """Add a RouteTable object to the net config object.
 
         :param route_table: the RouteTable object to add.
         """
-        logger.info(f'adding route table: {route_table.table_id} '
-                    f'{route_table.name}')
+        logger.info(
+            "ROUTE: adding route table: %s %s",
+            route_table.name,
+            route_table.table_id,
+        )
         self.route_table_data[int(route_table.table_id)] = route_table.name
         location = route_table_config_path()
         data = self.generate_route_table_config(self.route_table_data)
@@ -1219,8 +1247,9 @@ class NmstateNetConfig(os_net_config.NetConfig):
             elif table_id in rt_tables:
                 return rt_tables[table_id]
             else:
-                logger.error(f'Unidentified mapping for table_id '
-                             '{table_id}')
+                logger.error(
+                    "IP-RULES: Unidentified mapping for table_id %s", table_id
+                )
 
     def _parse_ip_rules(self, rule):
         """Parse IP rule commands
@@ -1246,7 +1275,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
             'priority': {'nm_key': NMRouteRule.PRIORITY, 'nm_value': None},
             'table': {'nm_key': NMRouteRule.ROUTE_TABLE, 'nm_value': None,
                       'nm_parse_value': self.rules_table_value_parse}}
-        logger.debug(f"Parse Rule {rule}")
+        logger.debug("IP-RULES: Parsing Rule: %s", rule)
         items = rule.split()
         keyword = items[0]
         parse_start_index = 1
@@ -1256,7 +1285,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
         elif keyword in nm_rule_map.keys():
             parse_start_index = 0
         elif keyword != 'add':
-            msg = f"unhandled ip rule command {rule}"
+            msg = f"IP-RULES: unhandled command: {rule}"
             raise os_net_config.ConfigurationError(msg)
 
         items_iter = iter(items[parse_start_index:])
@@ -1266,7 +1295,6 @@ class NmstateNetConfig(os_net_config.NetConfig):
             try:
                 parse_complete = True
                 item = next(items_iter)
-                logger.debug(f"parse item {item}")
                 if item in nm_rule_map.keys():
                     value = _get_type_value(nm_rule_map[item]['nm_value'])
                     if not value:
@@ -1276,11 +1304,11 @@ class NmstateNetConfig(os_net_config.NetConfig):
                             value = nm_rule_map[item]['nm_parse_value'](value)
                     rule_config[nm_rule_map[item]['nm_key']] = value
                 else:
-                    msg = f"unhandled ip rule command {rule}"
+                    msg = f"IP-RULES: unhandled command: {rule}"
                     raise os_net_config.ConfigurationError(msg)
             except StopIteration:
                 if not parse_complete:
-                    msg = f"incomplete ip rule command {rule}"
+                    msg = f"IP-RULES: incomplete command: {rule}"
                     raise os_net_config.ConfigurationError(msg)
                 break
 
@@ -1300,9 +1328,12 @@ class NmstateNetConfig(os_net_config.NetConfig):
             rule_config[NMRouteRule.FAMILY] = NMRouteRule.FAMILY_IPV4
 
         if NMRouteRule.PRIORITY not in rule_config.keys():
-            logger.warning(f"The ip rule {rule} doesn't have the priority set."
-                           "Its advisable to configure the priorities in "
-                           "order to have a deterministic behaviour")
+            logger.warning(
+                "The ip rule %s doesn't have the priority set."
+                "Its advisable to configure the priorities in "
+                "order to have a deterministic behaviour",
+                rule,
+            )
 
         return rule_config
 
@@ -1317,7 +1348,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
             rule_nm = self._parse_ip_rules(rule.rule)
             self.rules_data.append(rule_nm)
 
-        logger.debug(f'{interface_name}: rule data\n{self.rules_data}')
+        logger.debug("%s: rule data\n%s", interface_name, self.rules_data)
 
     def _add_dns_servers(self, dns_servers):
         """Add dns servers in nmstate schema format
@@ -1326,7 +1357,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
         """
         for dns_server in dns_servers:
             if dns_server not in self.dns_data['server']:
-                logger.debug(f"Adding DNS server {dns_server}")
+                logger.debug("DNS: Adding DNS server %s", dns_server)
                 self.dns_data['server'].append(dns_server)
 
     def _add_dns_domain(self, dns_domain):
@@ -1335,13 +1366,13 @@ class NmstateNetConfig(os_net_config.NetConfig):
         :param dns_domain: A list of DNS domains
         """
         if isinstance(dns_domain, str):
-            logger.debug(f"Adding DNS domain {dns_domain}")
+            logger.debug("DNS: Adding DNS domain %s", dns_domain)
             self.dns_data['domain'].extend([dns_domain])
             return
 
         for domain in dns_domain:
             if domain not in self.dns_data['domain']:
-                logger.debug(f"Adding DNS domain {domain}")
+                logger.debug("DNS: Adding DNS domain %s", domain)
                 self.dns_data['domain'].append(domain)
 
     def add_dispatch_script(self, device_data, stage, cmd):
@@ -1395,7 +1426,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
 
         if self.migration_enabled:
             self._clean_iface(interface.name, InterfaceType.ETHERNET)
-        logger.info(f'adding interface: {interface.name}')
+        logger.info("%s: adding interface", interface.name)
         data = self._add_common(interface)
 
         data[Interface.TYPE] = InterfaceType.ETHERNET
@@ -1414,13 +1445,14 @@ class NmstateNetConfig(os_net_config.NetConfig):
                                     interface.ethtool_opts)
 
         if interface.renamed:
-            logger.info(f"Interface {interface.hwname} being renamed to"
-                        f"{interface.name}")
+            logger.info(
+                "%s: renamed from %s", interface.name, interface.hwname
+            )
             self.renamed_interfaces[interface.hwname] = interface.name
         if interface.hwaddr:
             data[Interface.MAC] = interface.hwaddr
 
-        logger.debug(f'interface data: {data}')
+        self.__dump_key_config(data, msg=f"{interface.name}: Prepared config")
         self.interface_data[interface.name] = data
 
     def add_vlan(self, vlan):
@@ -1433,7 +1465,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
                 self._clean_iface(vlan.name, InterfaceType.OVS_INTERFACE)
             else:
                 self._clean_iface(vlan.name, InterfaceType.VLAN)
-        logger.info(f'adding vlan: {vlan.name}')
+        logger.info("%s: adding vlan", vlan.name)
 
         data = self._add_common(vlan)
         if vlan.device:
@@ -1451,8 +1483,8 @@ class NmstateNetConfig(os_net_config.NetConfig):
             data[VLAN.CONFIG_SUBTREE][VLAN.ID] = vlan.vlan_id
             data[VLAN.CONFIG_SUBTREE][VLAN.BASE_IFACE] = base_iface
 
-        logger.debug(f'vlan data: {data}')
         self.vlan_data[vlan.name] = data
+        self.__dump_key_config(data, msg=f"{vlan.name}: Prepared config")
 
     def _ovs_extra_cfg_eq_val(self, ovs_extra, cmd_map, data):
         """Parse ovs extra of the format key=value
@@ -1466,7 +1498,6 @@ class NmstateNetConfig(os_net_config.NetConfig):
         :raises ConfigurationError: Invalid ovs_extra format
         """
         index = 0
-        logger.info(f'Current ovs_extra {ovs_extra}')
         for a, b in zip(ovs_extra, cmd_map['command']):
             if not re.match(b, a, re.IGNORECASE):
                 return False
@@ -1483,26 +1514,32 @@ class NmstateNetConfig(os_net_config.NetConfig):
                         if m:
                             value = _get_type_value(m.group(1))
                     if value is None:
-                        msg = "Invalid ovs_extra format detected. "\
-                              f"{' '.join(ovs_extra)}"
+                        msg = (
+                            "ovs_extra: Invalid format detected. \n"
+                            f"{' -- '.join(ovs_extra)}"
+                        )
                         raise os_net_config.ConfigurationError(msg)
-                    config = _add_sub_tree(data, cfg['sub_tree'])
-                    if cfg['nm_config']:
-                        config[cfg['nm_config']] = value
-                    elif cfg['nm_config_regex']:
-                        logger.info(f'Regex pattern seen for {ovs_extra}')
-                        m = re.search(cfg['nm_config_regex'], ovs_extra[idx])
+                    config = _add_sub_tree(data, cfg["sub_tree"])
+                    if cfg["nm_config"]:
+                        key = cfg["nm_config"]
+                        config[key] = value
+                    elif cfg["nm_config_regex"]:
+                        m = re.search(cfg["nm_config_regex"], ovs_extra[idx])
                         if m:
-                            config[m.group(1)] = value
+                            key = m.group(1)
+                            config[key] = value
                         else:
-                            msg = "Invalid ovs_extra format detected. "\
-                                  f"{' '.join(ovs_extra)}"
+                            msg = (
+                                "ovs_extra: Invalid format detected.\n"
+                                f"{' -- '.join(ovs_extra)}"
+                            )
                             raise os_net_config.ConfigurationError(msg)
                     else:
                         msg = 'NM config not found'
                         raise os_net_config.ConfigurationError(msg)
-                    logger.info(f"Adding ovs_extra {config} in "
-                                f"{cfg['sub_tree']}")
+                    logger.info(
+                        "%s=%s", "->".join(cfg["sub_tree"] + [(key)]), value
+                    )
 
     def _ovs_extra_cfg_val(self, ovs_extra, cmd_map, data):
         """Parse ovs extra where key,value are seperated by spaces
@@ -1533,25 +1570,32 @@ class NmstateNetConfig(os_net_config.NetConfig):
                         if m:
                             value = _get_type_value(m.group(1))
                     if value is None:
-                        msg = f"Invalid ovs_extra format detected."\
-                              f"{' '.join(ovs_extra)}"
+                        msg = (
+                            "ovs_extra: Invalid format detected.\n"
+                            f"{' -- '.join(ovs_extra)}"
+                        )
                         raise os_net_config.ConfigurationError(msg)
                     config = _add_sub_tree(data, cfg['sub_tree'])
-                    if cfg['nm_config']:
-                        config[cfg['nm_config']] = value
+                    if cfg["nm_config"]:
+                        key = cfg["nm_config"]
+                        config[key] = value
                     elif cfg['nm_config_regex']:
                         m = re.search(cfg['nm_config_regex'], ovs_extra[index])
                         if m:
-                            config[m.group(1)] = value
+                            key = m.group(1)
+                            config[key] = value
                         else:
-                            msg = f"Invalid ovs_extra format detected."\
-                                  f"{' '.join(ovs_extra)}"
+                            msg = (
+                                "ovs_extra: Invalid format detected.\n"
+                                f"{' -- '.join(ovs_extra)}"
+                            )
                             raise os_net_config.ConfigurationError(msg)
                     else:
                         msg = 'NM config not found'
                         raise os_net_config.ConfigurationError(msg)
-                    logger.info(f"Adding ovs_extra {config} in "
-                                f"{cfg['sub_tree']}")
+                    logger.info(
+                        "%s=%s", "->".join(cfg["sub_tree"] + [key]), value
+                    )
 
     def parse_ovs_extra_for_bond(self, ovs_extras, name, data):
         """Parse ovs extra for bonding options
@@ -1566,19 +1610,19 @@ class NmstateNetConfig(os_net_config.NetConfig):
         # and not the Nmstate schema
         port_cfg = [
             {'config': r'^bond_mode=[\w+]',
-             'sub_tree': None,
+             'sub_tree': [],
              'nm_config': 'bond_mode',
              'value_pattern': r'^bond_mode=(.+?)$'},
             {'config': r'^lacp=[\w+]',
-             'sub_tree': None,
+             'sub_tree': [],
              'nm_config': 'lacp',
              'value_pattern': r'^lacp=(.+?)$'},
             {'config': r'^bond_updelay=[\w+]',
-             'sub_tree': None,
+             'sub_tree': [],
              'nm_config': 'bond_updelay',
              'value_pattern': r'^bond_updelay=(.+?)$'},
             {'config': r'^other_config:[\w+]',
-             'sub_tree': None,
+             'sub_tree': [],
              'nm_config': None,
              'nm_config_regex': r'^(.+?)=.*$',
              'value_pattern': r'^other_config:.*=(.+?)$'}]
@@ -1589,6 +1633,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
                             'action': port_cfg}]
 
         for ovs_extra in ovs_extras:
+            logger.debug("%s: Parse - %s", name, ovs_extra)
             ovs_extra_cmd = ovs_extra.split(' ')
             for cmd_map in cfg_eq_val_pair:
                 self._ovs_extra_cfg_eq_val(ovs_extra_cmd, cmd_map, data)
@@ -1670,6 +1715,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
         # ovs-vsctl set Interface $name <config>=<value>
         # ovs-vsctl br-set-external-id $name key [value]
         for ovs_extra in ovs_extras:
+            logger.info("%s: Parse - %s", name, ovs_extra)
             ovs_extra_cmd = ovs_extra.split(' ')
             for cmd_map in cfg_eq_val_pair:
                 self._ovs_extra_cfg_eq_val(ovs_extra_cmd, cmd_map, data)
@@ -1696,6 +1742,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
                                         '({name}|%s)' % bridge_name],
                             'action': port_vlan_cfg}]
         for ovs_extra in ovs_extras:
+            logger.info("%s: Parse - %s", bridge_name, ovs_extra)
             ovs_extra_cmd = ovs_extra.split(' ')
             for cmd_map in cfg_eq_val_pair:
                 self._ovs_extra_cfg_eq_val(ovs_extra_cmd, cmd_map, data)
@@ -1732,11 +1779,10 @@ class NmstateNetConfig(os_net_config.NetConfig):
 
         ovs_int_port = {'name': ovs_interface_port.name}
         if bridge.ovs_extra:
-            logger.info(f"Parsing ovs_extra for ports: {bridge.ovs_extra}")
             self.parse_ovs_extra_for_ports(bridge.ovs_extra,
                                            bridge.name, ovs_int_port)
 
-        logger.info(f'adding bridge: {bridge.name}')
+        logger.info("%s: adding bridge", bridge.name)
 
         # Clear the settings from the bridge, since these will be applied
         # on the interface
@@ -1793,11 +1839,16 @@ class NmstateNetConfig(os_net_config.NetConfig):
                     bond_options = {}
                     self.parse_ovs_extra_for_bond(
                         member.ovs_extra, member.name, bond_options)
-                    logger.debug(f'{member.name}: Bond options from '
-                                 f'ovs_extra\n{bond_options}')
+                    logger.debug(
+                        "%s: Bond options from ovs_extra\n%s",
+                        member.name,
+                        bond_options,
+                    )
                     if ovs_port:
-                        msg = "Ovs Bond and ovs port can't be members to "\
-                              "the ovs bridge"
+                        msg = (
+                            f"{bridge.name}: Ovs Bond and ovs port can't"
+                            "be members to the same ovs bridge"
+                        )
                         raise os_net_config.ConfigurationError(msg)
                     if member.primary_interface_name:
                         add_bond_setting = "other_config:bond-primary="\
@@ -1808,11 +1859,17 @@ class NmstateNetConfig(os_net_config.NetConfig):
                         else:
                             member.ovs_options = add_bond_setting
 
-                    logger.debug(f'{member.name}: Bond options from '
-                                 f'ovs_options:\n{member.ovs_options}')
+                    logger.debug(
+                        "%s: Bond options from ovs_options:\n%s",
+                        member.name,
+                        member.ovs_options,
+                    )
                     bond_options |= parse_bonding_options(member.ovs_options)
-                    logger.info(f'{member.name}: Aggregated bond options - '
-                                f'{bond_options}')
+                    logger.info(
+                        "%s: Aggregated bond options - %s",
+                        member.name,
+                        bond_options,
+                    )
                     bond_data = set_ovs_bonding_options(bond_options)
                     bond_port = [{
                         OVSBridge.Port.LINK_AGGREGATION_SUBTREE: bond_data,
@@ -1822,22 +1879,21 @@ class NmstateNetConfig(os_net_config.NetConfig):
                          ][OVSBridge.PORT_SUBTREE] = bond_port
 
                     ovs_bond = True
-                    logger.debug("OVS Bond members %s added" % members)
                     if member.members:
                         members = [m.name for m in member.members]
                 elif ovs_bond:
-                    msg = "Ovs Bond and ovs port can't be members to "\
-                          "the ovs bridge"
+                    msg = (
+                        f"{bridge.name}: ovs bond and ovs port can't be"
+                        "members to the ovs bridge"
+                    )
                     raise os_net_config.ConfigurationError(msg)
                 else:
                     ovs_port = True
-                    logger.debug("Adding member ovs port %s" % member.name)
                     members.append(member.name)
             if members:
-                logger.debug("Add ovs ports and vlans to ovs bridge")
                 bps = self.get_ovs_ports(members)
             else:
-                msg = "No members added for ovs bridge"
+                msg = f"{bridge.name}: no member added to ovs bridge"
                 raise os_net_config.ConfigurationError(msg)
 
             self.member_names[bridge.name] = members
@@ -1847,18 +1903,30 @@ class NmstateNetConfig(os_net_config.NetConfig):
                 bps.append(ovs_int_port)
                 data[OVSBridge.CONFIG_SUBTREE][
                     OVSBridge.PORT_SUBTREE].extend(bps)
+                bps_names = [port.get("name", "") for port in bps]
+                logger.debug(
+                    "%s: adding ovs ports - %s",
+                    bridge.name,
+                    " ".join(bps_names),
+                )
             elif ovs_bond:
                 bond_data[OVSBridge.Port.LinkAggregation.PORT_SUBTREE] = bps
+                bps_names = [port.get("name", "") for port in bps]
+                logger.debug(
+                    "%s: adding ovs ports - %s",
+                    bridge.members[0].name,
+                    " ".join(bps_names),
+                )
 
         self.bridge_data[bridge.name] = data
-        logger.debug('bridge data: %s' % data)
+        self.__dump_config(data, msg=f"{bridge.name}: Prepared config")
 
     def add_ovs_user_bridge(self, bridge):
         """Add an OvsUserBridge object to the net config object.
 
         :param bridge: The OvsUserBridge object to add.
         """
-        logger.info('adding ovs user bridge: %s' % bridge.name)
+        logger.info("%s: adding ovs user bridge", bridge.name)
         self.add_bridge(bridge, dpdk=True)
 
     def attach_patch_port_with_bridge(self, patch_port):
@@ -1881,7 +1949,9 @@ class NmstateNetConfig(os_net_config.NetConfig):
             port.append(patch_port_config)
 
         self.bridge_data[patch_port.bridge_name] = patch_br_data
-        logger.info('bridge_data: %s' % self.bridge_data)
+        self.__dump_config(
+            patch_br_data, msg=f"{patch_port.bridge_name}: Prepared config"
+        )
         return
 
     def add_ovs_patch_port(self, ovs_patch_port):
@@ -1892,16 +1962,16 @@ class NmstateNetConfig(os_net_config.NetConfig):
         if self.migration_enabled:
             self._clean_iface(ovs_patch_port.name, OVSInterface.TYPE)
 
-        logger.info('adding ovs patch port: %s' % ovs_patch_port.name)
+        logger.info("%s: adding ovs patch port", ovs_patch_port.name)
         data = self._add_common(ovs_patch_port)
         data[Interface.TYPE] = OVSInterface.TYPE
         data[Interface.STATE] = InterfaceState.UP
         data[OVSInterface.PATCH_CONFIG_SUBTREE] = \
             {OVSInterface.Patch.PEER: ovs_patch_port.peer}
-        logger.debug('ovs patch port data: %s' % data)
         self.interface_data[ovs_patch_port.name] = data
 
         self.attach_patch_port_with_bridge(ovs_patch_port)
+        self.__dump_config(data, msg=f"{ovs_patch_port.name}: Prepared config")
 
     def add_ovs_interface(self, ovs_interface):
         """Add a OvsInterface object to the net config object.
@@ -1911,15 +1981,15 @@ class NmstateNetConfig(os_net_config.NetConfig):
         if self.migration_enabled:
             self._clean_iface(ovs_interface.name, OVSInterface.TYPE)
 
-        logger.info('adding ovs interface: %s' % ovs_interface.name)
+        logger.info("%s: adding ovs interface", ovs_interface.name)
         data = self._add_common(ovs_interface)
         data[Interface.TYPE] = OVSInterface.TYPE
         data[Interface.STATE] = InterfaceState.UP
 
         if ovs_interface.hwaddr:
             data[Interface.MAC] = ovs_interface.hwaddr
-        logger.debug(f'add ovs_interface data: {data}')
         self.interface_data[ovs_interface.name + '-if'] = data
+        self.__dump_config(data, msg=f"{ovs_interface.name}: Prepared config")
 
     def add_ovs_dpdk_port(self, ovs_dpdk_port):
         """Add a OvsDpdkPort object to the net config object.
@@ -1929,7 +1999,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
         if self.migration_enabled:
             self._clean_iface(ovs_dpdk_port.name, OVSInterface.TYPE)
 
-        logger.info('adding ovs dpdk port: %s' % ovs_dpdk_port.name)
+        logger.info("%s: adding ovs dpdk port", ovs_dpdk_port.name)
 
         # DPDK Port will have only one member of type Interface, validation
         # checks are added at the object creation stage.
@@ -1966,12 +2036,13 @@ class NmstateNetConfig(os_net_config.NetConfig):
         data[OvsDB.KEY] = {OvsDB.EXTERNAL_IDS: {},
                            OvsDB.OTHER_CONFIG: {}}
         if ovs_dpdk_port.ovs_extra:
-            logger.info(f"Parsing ovs_extra : {ovs_dpdk_port.ovs_extra}")
+            logger.info(
+                "%s: Parse - %s", ovs_dpdk_port.name, ovs_dpdk_port.ovs_extra
+            )
             self.parse_ovs_extra(ovs_dpdk_port.ovs_extra,
                                  ovs_dpdk_port.name, data)
-
-        logger.debug(f'ovs dpdk port data: {data}')
         self.interface_data[ovs_dpdk_port.name] = data
+        self.__dump_config(data, msg=f"{ovs_dpdk_port.name}: Prepared config")
 
     def add_linux_bridge(self, bridge):
         """Add a LinuxBridge object to the net config object.
@@ -1981,10 +2052,10 @@ class NmstateNetConfig(os_net_config.NetConfig):
         if self.migration_enabled:
             self._clean_iface(bridge.name, InterfaceType.LINUX_BRIDGE)
 
-        logger.info(f'adding linux bridge: {bridge.name}')
+        logger.info("%s: adding linux bridge", bridge.name)
         data = self._add_common(bridge)
-        logger.debug('bridge data: %s' % data)
         self.linuxbridge_data[bridge.name] = data
+        self.__dump_config(data, msg=f"{bridge.name}: Prepared config")
 
     def add_bond(self, bond):
         """Add an OvsBond object to the net config object.
@@ -1992,7 +2063,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
         :param bond: The OvsBond object to add.
         """
         # The ovs bond is already added in add_bridge()
-        logger.info('adding bond: %s' % bond.name)
+        logger.info("%s: adding bond", bond.name)
         return
 
     def add_ovs_dpdk_bond(self, bond):
@@ -2000,7 +2071,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
 
         :param bond: The OvsBond object to add.
         """
-        logger.info('adding Ovs DPDK Bond: %s' % bond.name)
+        logger.info("%s: adding ovs_dpdk_bond", bond.name)
         for member in bond.members:
             if bond.mtu:
                 member.mtu = bond.mtu
@@ -2023,7 +2094,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
         if self.migration_enabled:
             self._clean_iface(bond.name, InterfaceType.BOND)
 
-        logger.info('adding linux bond: %s' % bond.name)
+        logger.info("%s: adding linux bond", bond.name)
         data = self._add_common(bond)
 
         data[Interface.TYPE] = InterfaceType.BOND
@@ -2043,8 +2114,8 @@ class NmstateNetConfig(os_net_config.NetConfig):
             self.member_names[bond.name] = members
             data[Bond.CONFIG_SUBTREE][Bond.PORT] = members
 
-        logger.debug('bond data: %s' % data)
         self.linuxbond_data[bond.name] = data
+        self.__dump_config(data, msg=f"{bond.name}: Prepared config")
 
     def add_sriov_pf(self, sriov_pf):
         """Add a SriovPF object to the net config object
@@ -2056,9 +2127,12 @@ class NmstateNetConfig(os_net_config.NetConfig):
         if self.migration_enabled:
             self._clean_iface(sriov_pf.name, InterfaceType.ETHERNET)
 
-        logger.info(f'adding sriov pf: {sriov_pf.name}')
+        logger.info("%s: adding sriov pf", sriov_pf.name)
         if sriov_pf.vdpa or sriov_pf.link_mode == 'switchdev':
-            msg = "Switchdev/vDPA is not supported by nmstate provider yet."
+            msg = (
+                f"{sriov_pf.name}: switchdev/vDPA is not supported "
+                "by nmstate provider yet."
+            )
             raise os_net_config.ConfigurationError(msg)
 
         data = self._add_common(sriov_pf)
@@ -2078,9 +2152,11 @@ class NmstateNetConfig(os_net_config.NetConfig):
                 Ethernet.SRIOV.DRIVERS_AUTOPROBE: sriov_pf.drivers_autoprobe,
             }
         else:
-            msg = (f'{sriov_pf.name}: Maximum numvfs supported '
-                   f'({max_vfs}) is lesser than user requested '
-                   f'numvfs ({sriov_pf.numvfs})')
+            msg = (
+                f"{sriov_pf.name}: maximum numvfs supported "
+                f"({max_vfs}) is lesser than user requested "
+                f"numvfs ({sriov_pf.numvfs})"
+            )
             raise os_net_config.ConfigurationError(msg)
 
         if sriov_pf.promisc:
@@ -2096,11 +2172,11 @@ class NmstateNetConfig(os_net_config.NetConfig):
             self.add_ethtool_config(sriov_pf.name, data,
                                     sriov_pf.ethtool_opts)
 
-        logger.debug('sriov pf data: %s' % data)
         self.sriov_vf_data[sriov_pf.name] = [None] * sriov_pf.numvfs
         self.sriov_pf_data[sriov_pf.name] = data
         self.vf_drv_override[sriov_pf.name] = {}
         self.need_pf_config = True
+        self.__dump_config(data, msg=f"{sriov_pf.name}: Prepared config")
 
     def add_sriov_vf(self, sriov_vf):
         """Add a SriovVF object to the net config object
@@ -2112,30 +2188,32 @@ class NmstateNetConfig(os_net_config.NetConfig):
         if self.migration_enabled:
             self._clean_iface(sriov_vf.name, InterfaceType.ETHERNET)
 
-        logger.info('adding sriov vf: %s for pf: %s, vfid: %d'
-                    % (sriov_vf.name, sriov_vf.device, sriov_vf.vfid))
+        logger.info("%s-%d: adding vf", sriov_vf.device, sriov_vf.vfid)
         data = self._add_common(sriov_vf)
         data[Interface.TYPE] = InterfaceType.ETHERNET
         data[Ethernet.CONFIG_SUBTREE] = {}
         if sriov_vf.promisc:
             data[Interface.ACCEPT_ALL_MAC_ADDRESSES] = True
-        logger.debug('sriov vf data: %s' % data)
         self.interface_data[sriov_vf.name] = data
-        vf_config = self.get_vf_config(sriov_vf)
-        logger.debug("Adding vf config %s" % vf_config)
 
         # sriov_vf_data is a list of vf configuration data of size numvfs.
         # The vfid is used as index.
         if sriov_vf.device not in self.sriov_vf_data:
-            msg = f"VF configuration is seen while the parent device"\
-                  f" {sriov_vf.device} is not availavle"
+            msg = f"{sriov_vf.device}: PF is not configured yet"
             raise os_net_config.ConfigurationError(msg)
 
+        vf_config = self.get_vf_config(sriov_vf)
+        logger.debug(
+            "%s-%d: vf config %s", sriov_vf.device, sriov_vf.vfid, vf_config
+        )
         self.sriov_vf_data[sriov_vf.device][sriov_vf.vfid] = vf_config
         if sriov_vf.ethtool_opts:
             self.add_ethtool_config(sriov_vf.name, data,
                                     sriov_vf.ethtool_opts)
         self.need_vf_config = True
+        self.__dump_config(
+            data, msg=(f"{sriov_vf.device}-{sriov_vf.vfid}: Prepared config")
+        )
 
     def add_ib_interface(self, ib_interface):
         """Add an InfiniBand interface object to the net config object.
@@ -2145,9 +2223,8 @@ class NmstateNetConfig(os_net_config.NetConfig):
         if self.migration_enabled:
             self._clean_iface(ib_interface.name, InterfaceType.INFINIBAND)
 
-        logger.info('adding ib_interface: %s' % ib_interface.name)
+        logger.info("%s: adding ib_interface", ib_interface.name)
         data = self._add_common(ib_interface)
-        logger.debug('ib_interface data: %s' % data)
         data[Interface.TYPE] = InterfaceType.INFINIBAND
         if ib_interface.ethtool_opts:
             self.add_ethtool_config(ib_interface.name, data,
@@ -2158,6 +2235,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
         config[InfiniBand.MODE] = InfiniBand.Mode.DATAGRAM
         data[InfiniBand.CONFIG_SUBTREE] = config
         self.interface_data[ib_interface.name] = data
+        self.__dump_config(data, msg=f"{ib_interface.name}: Prepared config")
 
     def add_ib_child_interface(self, ib_child_interface):
         """Add an InfiniBand child interface object to the net config object.
@@ -2169,9 +2247,8 @@ class NmstateNetConfig(os_net_config.NetConfig):
             self._clean_iface(ib_child_interface.name,
                               InterfaceType.INFINIBAND)
 
-        logger.info('adding ib_child_interface: %s' % ib_child_interface.name)
+        logger.info("%s: adding ib_child_interface", ib_child_interface.name)
         data = self._add_common(ib_child_interface)
-        logger.debug('ib_child_interface data: %s' % data)
         data[Interface.TYPE] = InterfaceType.INFINIBAND
         config = {}
         config[InfiniBand.PKEY] = ib_child_interface.pkey_id
@@ -2181,6 +2258,9 @@ class NmstateNetConfig(os_net_config.NetConfig):
         config[InfiniBand.MODE] = InfiniBand.Mode.DATAGRAM
         data[InfiniBand.CONFIG_SUBTREE] = config
         self.interface_data[ib_child_interface.name] = data
+        self.__dump_config(
+            data, msg=f"{ib_child_interface.name}: Prepared config"
+        )
 
     def apply(self, cleanup=False, activate=True, config_rules_dns=True):
         """Apply the network configuration.
@@ -2201,9 +2281,8 @@ class NmstateNetConfig(os_net_config.NetConfig):
             mode).
         Note the noop mode is set via the constructor noop boolean
         """
-        logger.info('applying network configs...')
+        logger.info('applying network configs....')
         if cleanup:
-            logger.info('Cleaning up all network configs...')
             self.cleanup_all_ifaces()
 
         add_routes = []
@@ -2212,7 +2291,6 @@ class NmstateNetConfig(os_net_config.NetConfig):
         updated_interfaces = {}
         updated_pfs = []
 
-        logger.debug("----------------------------")
         if self.need_pf_config:
             pf_devs = self.apply_pf_config(activate)
             updated_pfs.extend(pf_devs)
@@ -2232,8 +2310,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
             if not is_dict_subset(iface_state, iface_data):
                 updated_interfaces[interface_name] = iface_data
             else:
-                logger.info('No changes required for interface: '
-                            f'{interface_name}')
+                logger.info("%s : no change required", interface_name)
             add_route, del_route = self.generate_routes(interface_name)
             add_routes.extend(add_route)
             del_routes.extend(del_route)
@@ -2244,8 +2321,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
             if not is_dict_subset(bridge_state, bridge_data):
                 updated_interfaces[bridge_name] = bridge_data
             else:
-                logger.info('No changes required for bridge: %s' %
-                            bridge_name)
+                logger.info("%s: no change required", bridge_name)
 
             add_route, del_route = self.generate_routes(bridge_name)
             add_routes.extend(add_route)
@@ -2256,8 +2332,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
             if not is_dict_subset(bond_state, bond_data):
                 updated_interfaces[bond_name] = bond_data
             else:
-                logger.info('No changes required for bond: %s' %
-                            bond_name)
+                logger.info("%s: no change required", bond_name)
             add_route, del_route = self.generate_routes(bond_name)
             add_routes.extend(add_route)
             del_routes.extend(del_route)
@@ -2267,8 +2342,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
             if not is_dict_subset(vlan_state, vlan_data):
                 updated_interfaces[vlan_name] = vlan_data
             else:
-                logger.info('No changes required for vlan interface: %s' %
-                            vlan_name)
+                logger.info("%s: no change required", vlan_name)
             add_route, del_route = self.generate_routes(vlan_name)
             add_routes.extend(add_route)
             del_routes.extend(del_route)
@@ -2321,9 +2395,11 @@ class NmstateNetConfig(os_net_config.NetConfig):
         for pf in updated_pfs:
             updated_interfaces[pf] = self.sriov_pf_data[pf]
 
-        logger.debug(f'Updated the intrefaces: '
-                     f'{" ".join(updated_interfaces.keys())}')
+        logger.debug(
+            "Updated the interfaces: %s", " ".join(updated_interfaces.keys())
+        )
 
-        logger.info('Succesfully applied the network configuration with '
-                    'nmstate provider')
+        logger.info(
+            "Succesfully applied the network config with nmstate provider"
+        )
         return updated_interfaces

--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -161,20 +161,25 @@ def mapped_nics(nic_mapping=None):
                     except IOError:
                         continue
                     if nic_mapped == mac:
-                        logger.debug("%s matches device %s" %
-                                     (nic_mapped, nic))
+                        logger.debug("%s matches device %s", nic_mapped, nic)
                         nic_mapped = nic
                         break
                 else:
                     # The mac could not be found on this system
-                    logger.error('mac %s not found in available nics (%s)'
-                                 % (nic_mapped, ', '.join(available_nics)))
+                    logger.error(
+                        "mac %s not found in available nics %s",
+                        nic_mapped,
+                        ", ".join(available_nics),
+                    )
                     continue
 
             elif nic_mapped not in available_nics:
                 # nic doesn't exist on this system
-                logger.error('nic %s not found in available nics (%s)'
-                             % (nic_mapped, ', '.join(available_nics)))
+                logger.error(
+                    "nic %s not found in available nics %s",
+                    nic_mapped,
+                    ", ".join(available_nics),
+                )
                 continue
 
             # Duplicate mappings are not allowed
@@ -192,12 +197,13 @@ def mapped_nics(nic_mapping=None):
                        'NIC.' % (nic_mapped, nic_alias))
                 raise InvalidConfigException(msg)
             elif utils.is_real_nic(nic_alias):
-                logger.warning("Mapped nic %s overlaps with name of inactive "
-                               "NIC." % (nic_alias))
+                logger.warning(
+                    "Mapped nic %s overlaps with name of inactive NIC.",
+                    nic_alias,
+                )
 
             _MAPPED_NICS[nic_alias] = nic_mapped
-            logger.info("%s in mapping file mapped to: %s"
-                        % (nic_alias, nic_mapped))
+            logger.info("%s => %s", nic_alias, nic_mapped)
 
     # nics not in mapping file must be active in order to be mapped
     active_nics = utils.ordered_active_nics()
@@ -206,12 +212,15 @@ def mapped_nics(nic_mapping=None):
     for nic_mapped in set(active_nics).difference(set(_MAPPED_NICS.values())):
         nic_alias = "nic%i" % (active_nics.index(nic_mapped) + 1)
         if nic_alias in _MAPPED_NICS:
-            logger.warning("no mapping for interface %s because "
-                           "%s is mapped to %s"
-                           % (nic_mapped, nic_alias, _MAPPED_NICS[nic_alias]))
+            logger.warning(
+                "no mapping for interface %s because %s is mapped to %s",
+                nic_mapped,
+                nic_alias,
+                _MAPPED_NICS[nic_alias],
+            )
         else:
             _MAPPED_NICS[nic_alias] = nic_mapped
-            logger.info("%s mapped to: %s" % (nic_alias, nic_mapped))
+            logger.info("%s => %s", nic_alias, nic_mapped)
 
     if not _MAPPED_NICS:
         logger.warning('No active nics found.')
@@ -732,16 +741,25 @@ class OvsBridge(_BaseOpts):
     @staticmethod
     def update_vf_config(iface):
         if iface.trust is None:
-            logger.info("Trust is not set for VF %s:%d, defaulting to on"
-                        % (iface.device, iface.vfid))
+            logger.info(
+                "%s-%d: Trust is not set, defaulting to on",
+                iface.device,
+                iface.vfid
+            )
             iface.trust = "on"
         if iface.spoofcheck is None:
-            logger.info("Spoofcheck is not set for VF %s:%d, defaulting to off"
-                        % (iface.device, iface.vfid))
+            logger.info(
+                "%s-%d: Spoofcheck is not set, defaulting to off",
+                iface.device,
+                iface.vfid
+            )
             iface.spoofcheck = "off"
         if iface.promisc is None:
-            logger.info("Promisc is not set for VF %s:%d, defaulting to on"
-                        % (iface.device, iface.vfid))
+            logger.info(
+                "%s-%d: Promisc is not set, defaulting to on",
+                iface.device,
+                iface.vfid
+            )
             iface.promisc = "on"
         utils.update_sriov_vf_map(iface.device, iface.vfid, iface.name,
                                   vlan_id=iface.vlan_id, qos=iface.qos,
@@ -1113,16 +1131,25 @@ class LinuxBond(_BaseOpts):
     @staticmethod
     def update_vf_config(iface):
         if iface.trust is None:
-            logger.info("Trust is not set for VF %s:%d, defaulting to on"
-                        % (iface.device, iface.vfid))
+            logger.info(
+                "%s-%d: Trust is not set, defaulting to on",
+                iface.device,
+                iface.vfid,
+            )
             iface.trust = 'on'
         if iface.spoofcheck is None:
-            logger.info("Spoofcheck is not set for VF %s:%d, defaulting to off"
-                        % (iface.device, iface.vfid))
+            logger.info(
+                "%s-%d: Spoofcheck is not set, defaulting to off",
+                iface.device,
+                iface.vfid,
+            )
             iface.spoofcheck = 'off'
         if iface.promisc is None:
-            logger.info("Promisc is not set for VF %s:%d, defaulting to off"
-                        % (iface.device, iface.vfid))
+            logger.info(
+                "%s-%d: Promisc is not set, defaulting to off",
+                iface.device,
+                iface.vfid,
+            )
             iface.promisc = 'off'
         utils.update_sriov_vf_map(iface.device, iface.vfid, iface.name,
                                   vlan_id=iface.vlan_id, qos=iface.qos,
@@ -1201,16 +1228,25 @@ class OvsBond(_BaseOpts):
     @staticmethod
     def update_vf_config(iface):
         if iface.trust is None:
-            logger.info("Trust is not set for VF %s:%d, defaulting to on"
-                        % (iface.device, iface.vfid))
+            logger.info(
+                "%s-%d: Trust is not set, defaulting to on",
+                iface.device,
+                iface.vfid,
+            )
             iface.trust = "on"
         if iface.spoofcheck is None:
-            logger.info("Spoofcheck is not set for VF %s:%d, defaulting to off"
-                        % (iface.device, iface.vfid))
+            logger.info(
+                "%s-%d: Spoofcheck is not set, defaulting to off",
+                iface.device,
+                iface.vfid,
+            )
             iface.spoofcheck = "off"
         if iface.promisc is None:
-            logger.info("Promisc is not set for VF %s:%d, defaulting to on"
-                        % (iface.device, iface.vfid))
+            logger.info(
+                "%s-%d: Promisc is not set, defaulting to on",
+                iface.device,
+                iface.vfid,
+            )
             iface.promisc = "on"
         utils.update_sriov_vf_map(iface.device, iface.vfid, iface.name,
                                   vlan_id=iface.vlan_id, qos=iface.qos,
@@ -1429,18 +1465,32 @@ class OvsDpdkPort(_BaseOpts):
     @staticmethod
     def update_vf_config(iface, driver=None):
         if iface.trust is None:
-            logger.info("Trust is not set for VF %s:%d, defaulting to on"
-                        % (iface.device, iface.vfid))
+            logger.info(
+                "%s-%d: Trust is not set, defaulting to on",
+                iface.device,
+                iface.vfid,
+            )
             iface.trust = "on"
         if iface.spoofcheck is None:
-            logger.info("Spoofcheck is not set for VF %s:%d, defaulting to off"
-                        % (iface.device, iface.vfid))
+            logger.info(
+                "%s-%d: Spoofcheck is not set, defaulting to off",
+                iface.device,
+                iface.vfid,
+            )
             iface.spoofcheck = "off"
         if iface.promisc is not None:
-            logger.warning("Promisc can't be changed for ovs_dpdk_port")
+            logger.warning(
+                "%s-%d: Promisc can't be changed for ovs_dpdk_port",
+                iface.device,
+                iface.vfid,
+            )
             iface.promisc = None
-        logger.info(f'{iface.device}-{iface.vfid}: Overriding the default '
-                    f'driver for DPDK with {driver}')
+        logger.info(
+            "%s-%d: Overriding the default driver for DPDK with %s",
+            iface.device,
+            iface.vfid,
+            driver,
+        )
         iface.driver = driver
         utils.update_sriov_vf_map(iface.device, iface.vfid, iface.name,
                                   vlan_id=iface.vlan_id, qos=iface.qos,

--- a/os_net_config/sriov_bind_config.py
+++ b/os_net_config/sriov_bind_config.py
@@ -56,13 +56,13 @@ WantedBy=multi-user.target
 
 def get_file_data(filename):
     if not os.path.exists(filename):
-        logger.error("Error file is not exist: %s" % filename)
+        logger.error("%s: File does not exist", filename)
         raise FileNotFoundError(filename)
     try:
         with open(filename, 'r') as f:
             return f.read()
     except IOError:
-        logger.error("Error reading file: %s" % filename)
+        logger.error("%s: Error reading file", filename)
         raise
 
 
@@ -124,9 +124,9 @@ def bind_vfs(sriov_bind_pcis_map=None):
                 try:
                     with open(pci_driver_bind_file_path, 'w') as f:
                         f.write("%s" % vf_pci)
-                    logger.info("Vf %s has been bound" % vf_pci)
+                    logger.info("%s: Vf has been bound", vf_pci)
                 except IOError:
-                    logger.error("Failed to bind vf %s" % vf_pci)
+                    logger.error("%s: Failed to bind vf", vf_pci)
 
 
 def main():

--- a/os_net_config/tests/test_utils.py
+++ b/os_net_config/tests/test_utils.py
@@ -656,8 +656,8 @@ class TestUtils(base.TestCase):
             utils.bind_dpdk_interfaces('eth1', 'vfio-pci', False)
         except common.OvsDpdkBindException:
             self.fail("Received OvsDpdkBindException unexpectedly")
-        msg = "Driver (vfio-pci) is already bound to the device (eth1)"
-        mocked_logger.assert_called_with(msg)
+        msg = ["%s: Driver %s is already bound", "eth1", "vfio-pci"]
+        mocked_logger.assert_called_with(*msg)
 
     def test_get_interface_driver(self):
         mocked_open = mock.mock_open(read_data='DRIVER=vfio-pci\n')


### PR DESCRIPTION
These below issues are addressed here
- The logging in nmstate provider is printing the data structures in json format which is not easy to read and decipher. These data structures are printed in yaml format for the ease of reading.
- Some of the logs are repeated at several levels leading to duplication of the logging.
- All the logs are done in same format.

Conflicts resolved in os_net_config/cli.py
- 'is_nmstate_available' function not present in stable/wallaby. So, skipped that function log message changes


(cherry picked from commit 7209726bfa384db47caee9895f65305b6a72683e)