### PR TITLE
utils: simplify get_pci_address() implementation

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -340,7 +340,7 @@ def main(argv=sys.argv, main_logger=None):
         for iface_json in iface_array:
             try:
                 obj = objects.object_from_json(iface_json)
-            except utils.SriovVfNotFoundException:
+            except common.SriovVfNotFoundException:
                 continue
 
             if _is_sriovpf_obj_found(obj):
@@ -389,7 +389,7 @@ def main(argv=sys.argv, main_logger=None):
             # SriovVfNotFoundException shall be raised if not available.
             try:
                 obj = objects.object_from_json(iface_json)
-            except utils.SriovVfNotFoundException:
+            except common.SriovVfNotFoundException:
                 if not opts.noop:
                     raise
 

--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -1296,11 +1296,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param vpp_interface: The VppInterface object to add
         """
-        vpp_interface.pci_dev = utils.get_pci_address(vpp_interface.name,
-                                                      self.noop)
-        if not vpp_interface.pci_dev:
-            vpp_interface.pci_dev = utils.get_stored_pci_address(
-                vpp_interface.name, self.noop)
+        vpp_interface.pci_dev = common.get_pci_address(vpp_interface.name)
         vpp_interface.hwaddr = common.interface_mac(vpp_interface.name)
         if not self.noop:
             self.ifdown(vpp_interface.name)

--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -2012,7 +2012,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
         if isinstance(ovs_dpdk_port.members[0], objects.SriovVF):
             # in case of VFs the DPDK driver will be bound using
             # dispatcher script
-            pci_address = utils.get_dpdk_pci_address(ifname)
+            pci_address = ovs_dpdk_port.members[0].pci_address
             utils.update_dpdk_map(ifname,
                                   ovs_dpdk_port.driver)
         else:

--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -310,7 +310,7 @@ class Dcb(object):
         noop = common.get_noop()
         self.device = device
         self.dscp2prio = dscp2prio
-        self.pci_addr = utils.get_pci_address(device, noop)
+        self.pci_addr = common.get_pci_address(device)
         self.driver = utils.get_driver(device, noop)
 
     @staticmethod
@@ -1587,6 +1587,7 @@ class SriovVF(_BaseOpts):
         mapped_nic_names = mapped_nics(nic_mapping)
         if device in mapped_nic_names:
             device = mapped_nic_names[device]
+        pci_address = common.get_pci_address(f"sriov:{device}:{vfid}")
         # Empty strings are set for the name field.
         # The provider shall identify the VF name from the PF device name
         # (device) and the VF id.
@@ -1605,10 +1606,6 @@ class SriovVF(_BaseOpts):
         self.spoofcheck = spoofcheck
         self.trust = trust
         self.state = state
-        noop = common.get_noop()
-        pci_address = utils.get_pci_address(name, noop)
-        if pci_address is None:
-            pci_address = utils.get_stored_pci_address(name, noop)
         self.macaddr = macaddr
         self.promisc = promisc
         self.pci_address = pci_address

--- a/os_net_config/tests/test_cli.py
+++ b/os_net_config/tests/test_cli.py
@@ -75,17 +75,15 @@ class TestCli(base.TestCase):
         stderr = sys.stderr.getvalue()
         return (stdout, stderr)
 
-    def stub_get_stored_pci_address(self, ifname, noop):
-        if 'eth0' in ifname:
-            return "0000:00:07.0"
-        if 'eth1' in ifname:
-            return "0000:00:08.0"
-        if 'eth2' in ifname:
-            return "0000:00:09.0"
-        if 'em3' in ifname:
-            return "0000:00:03.0"
-        if 'em1' in ifname:
-            return "0000:00:01.0"
+    def stub_get_pci_address(self, ifname):
+        address_map = {
+            "eth0": "0000:00:07.0",
+            "eth1": "0000:00:08.0",
+            "eth2": "0000:00:09.0",
+            "em3": "0000:00:03.0",
+            "em1": "0000:00:01.0"
+        }
+        return address_map.get(ifname, None)
 
     def test_bond_noop_output(self):
         bond_yaml = os.path.join(SAMPLE_BASE, 'bond.yaml')
@@ -221,7 +219,7 @@ class TestCli(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         def test_interface_mac(name):
@@ -229,7 +227,7 @@ class TestCli(base.TestCase):
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
         self.stub_out('os_net_config.common.interface_mac',
                       test_interface_mac)
@@ -263,12 +261,12 @@ class TestCli(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
         pf_yaml = os.path.join(SAMPLE_BASE, 'sriov_pf_ovs_dpdk.yaml')
         pf_json = os.path.join(SAMPLE_BASE, 'sriov_pf_ovs_dpdk.json')
@@ -429,6 +427,7 @@ class TestCli(base.TestCase):
         self.assertEqual(stdout_yaml, stdout_json)
 
     def test_contrail_vrouter_dpdk_noop_output(self):
+        common.set_noop(False)
         timestamp_rex = re.compile(
             (r'contrail_vrouter_dpdk\.(yaml|json)|^[\d]{4}-[\d]{2}-[\d]{2} '
              r'[\d]{2}:[\d]{2}:[\d]{2}\.[\d]{3} '),
@@ -436,8 +435,8 @@ class TestCli(base.TestCase):
         )
         cvi_yaml = os.path.join(SAMPLE_BASE, 'contrail_vrouter_dpdk.yaml')
         cvi_json = os.path.join(SAMPLE_BASE, 'contrail_vrouter_dpdk.json')
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_pci_address',
+                      self.stub_get_pci_address)
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
                                            '--exit-on-validation-errors '
                                            '--debug '

--- a/os_net_config/tests/test_impl_ifcfg.py
+++ b/os_net_config/tests/test_impl_ifcfg.py
@@ -733,7 +733,7 @@ class TestIfcfgNetConfig(base.TestCase):
     def get_route6_config(self, name='em1'):
         return self.provider.route6_data.get(name, '')
 
-    def stub_get_stored_pci_address(self, ifname, noop):
+    def stub_get_dpdk_pci_address(self, ifname):
         if 'eth0' in ifname:
             return "0000:00:07.0"
         if 'eth1' in ifname:
@@ -1149,8 +1149,8 @@ class TestIfcfgNetConfig(base.TestCase):
     def test_add_contrail_vrouter_dpdk_interface(self):
         addresses = [objects.Address('10.0.0.30/24')]
         interface1 = objects.Interface('em3')
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
         cvi = objects.ContrailVrouterDpdk('vhost0', addresses=addresses,
                                           members=[interface1])
         self.provider.noop = True
@@ -1163,8 +1163,8 @@ class TestIfcfgNetConfig(base.TestCase):
     def test_add_contrail_vrouter_dpdk_interface_cust_driver(self):
         addresses = [objects.Address('10.0.0.30/24')]
         interface1 = objects.Interface('em3')
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
         cvi = objects.ContrailVrouterDpdk('vhost0', addresses=addresses,
                                           members=[interface1], driver='vfio')
         self.provider.noop = True
@@ -1179,8 +1179,8 @@ class TestIfcfgNetConfig(base.TestCase):
         self.stubbed_mapped_nics = nic_mapping
         addresses = [objects.Address('10.0.0.30/24')]
         interface1 = objects.Interface('nic1')
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
         cvi = objects.ContrailVrouterDpdk('vhost0', addresses=addresses,
                                           members=[interface1])
         self.provider.noop = True
@@ -1194,8 +1194,8 @@ class TestIfcfgNetConfig(base.TestCase):
         addresses = [objects.Address('10.0.0.30/24')]
         interface1 = objects.Interface('em3')
         interface2 = objects.Interface('em1')
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
         cvi = objects.ContrailVrouterDpdk('vhost0', addresses=addresses,
                                           members=[interface1, interface2],
                                           bond_mode="2",
@@ -1214,8 +1214,8 @@ class TestIfcfgNetConfig(base.TestCase):
         addresses = [objects.Address('10.0.0.30/24')]
         interface1 = objects.Interface('nic1')
         interface2 = objects.Interface('nic2')
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
         cvi = objects.ContrailVrouterDpdk('vhost0', addresses=addresses,
                                           members=[interface1, interface2],
                                           bond_mode="2",
@@ -1562,13 +1562,13 @@ DOMAIN="openstack.local subdomain.openstack.local"
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
 
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         vf = objects.SriovVF(device='nic3', vfid=7, addresses=addresses)
@@ -1615,13 +1615,13 @@ NETMASK=255.255.255.0
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:80:10.1'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
 
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         vf = objects.SriovVF(device='nic3', vfid=7, addresses=addresses,
@@ -1672,13 +1672,13 @@ NETMASK=255.255.255.0
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:82:00.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
 
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         vf = objects.SriovVF(device='nic3', vfid=7, addresses=addresses,
@@ -1760,8 +1760,8 @@ BOOTPROTO=none
             self.assertEqual(driver, 'vfio-pci')
         self.stub_out('os_net_config.utils.bind_dpdk_interfaces',
                       test_bind_dpdk_interfaces)
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
 
         self.provider.add_ovs_dpdk_port(dpdk_port)
         self.provider.add_ovs_user_bridge(bridge)
@@ -1809,8 +1809,8 @@ OVS_EXTRA="set Interface $DEVICE options:dpdk-devargs=0000:00:09.0"
             self.assertEqual(driver, 'mlx5_core')
         self.stub_out('os_net_config.utils.bind_dpdk_interfaces',
                       test_bind_dpdk_interfaces)
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
 
         self.provider.add_ovs_dpdk_port(dpdk_port)
         self.provider.add_ovs_user_bridge(bridge)
@@ -1865,8 +1865,8 @@ BOOTPROTO=none
             self.assertEqual(driver, 'vfio-pci')
         self.stub_out('os_net_config.utils.bind_dpdk_interfaces',
                       test_bind_dpdk_interfaces)
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
 
         self.provider.add_ovs_dpdk_port(dpdk_port)
         self.provider.add_ovs_user_bridge(bridge)
@@ -1914,8 +1914,8 @@ OVS_EXTRA="set Interface $DEVICE options:dpdk-devargs=0000:00:09.0 \
             self.assertEqual(driver, 'vfio-pci')
         self.stub_out('os_net_config.utils.bind_dpdk_interfaces',
                       test_bind_dpdk_interfaces)
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
 
         self.provider.add_ovs_dpdk_port(dpdk_port)
         self.provider.add_ovs_user_bridge(bridge)
@@ -1980,8 +1980,8 @@ LINKSTATUS=down
             self.assertEqual(driver, 'vfio-pci')
         self.stub_out('os_net_config.utils.bind_dpdk_interfaces',
                       test_bind_dpdk_interfaces)
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
 
         self.provider.add_ovs_dpdk_bond(bond)
         self.provider.add_ovs_user_bridge(bridge)
@@ -2028,8 +2028,8 @@ OVS_EXTRA="set Interface dpdk0 options:dpdk-devargs=0000:00:08.0 \
             self.assertEqual(driver, 'mlx5_core')
         self.stub_out('os_net_config.utils.bind_dpdk_interfaces',
                       test_bind_dpdk_interfaces)
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
 
         self.provider.add_ovs_dpdk_bond(bond)
         self.provider.add_ovs_user_bridge(bridge)
@@ -2090,8 +2090,8 @@ BOOTPROTO=none
             self.assertEqual(driver, 'vfio-pci')
         self.stub_out('os_net_config.utils.bind_dpdk_interfaces',
                       test_bind_dpdk_interfaces)
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
 
         self.provider.add_ovs_dpdk_bond(bond)
         self.provider.add_ovs_user_bridge(bridge)
@@ -2132,8 +2132,8 @@ OVS_EXTRA="set Interface dpdk0 options:dpdk-devargs=0000:00:08.0 \
             self.assertEqual(driver, 'vfio-pci')
         self.stub_out('os_net_config.utils.bind_dpdk_interfaces',
                       test_bind_dpdk_interfaces)
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
 
         self.provider.add_ovs_dpdk_bond(bond)
         self.provider.add_ovs_user_bridge(bridge)
@@ -2175,8 +2175,8 @@ OVS_EXTRA="set Interface dpdk0 options:dpdk-devargs=0000:00:08.0 \
             self.assertEqual(driver, 'vfio-pci')
         self.stub_out('os_net_config.utils.bind_dpdk_interfaces',
                       test_bind_dpdk_interfaces)
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
 
         self.provider.add_ovs_dpdk_bond(bond)
         self.provider.add_ovs_user_bridge(bridge)
@@ -2220,8 +2220,8 @@ OVS_EXTRA="set Interface dpdk0 options:dpdk-devargs=0000:00:08.0 \
             self.assertEqual(driver, 'vfio-pci')
         self.stub_out('os_net_config.utils.bind_dpdk_interfaces',
                       test_bind_dpdk_interfaces)
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      self.stub_get_stored_pci_address)
+        self.stub_out('os_net_config.common.get_dpdk_pci_address',
+                      self.stub_get_dpdk_pci_address)
 
         self.provider.add_ovs_dpdk_bond(bond)
         self.provider.add_ovs_user_bridge(bridge)

--- a/os_net_config/tests/test_objects.py
+++ b/os_net_config/tests/test_objects.py
@@ -486,12 +486,12 @@ class TestBridge(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         bridge = objects.object_from_json(json.loads(data))
@@ -549,12 +549,12 @@ class TestBridge(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         bridge = objects.object_from_json(json.loads(data))
@@ -620,12 +620,12 @@ class TestBridge(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         objects.object_from_json(json.loads(data))
@@ -662,12 +662,12 @@ class TestBridge(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
         bridge = objects.object_from_json(json.loads(data))
         self.assertEqual("br-foo", bridge.name)
@@ -738,12 +738,12 @@ class TestBridge(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         bridge = objects.object_from_json(json.loads(data))
@@ -795,12 +795,12 @@ class TestBridge(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         bridge = objects.object_from_json(json.loads(data))
@@ -1285,6 +1285,7 @@ class TestLinuxBond(base.TestCase):
         self.assertEqual("em2", interface2.name)
 
     def test_linux_bond_with_vf_default(self):
+        common.set_noop(False)
         data = """{
 "type": "linux_bond",
 "name": "bond1",
@@ -1326,15 +1327,15 @@ class TestLinuxBond(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
-            if ifname == 'em1_1':
-                return '0000:79:10.1'
-            elif ifname == 'em2_1':
-                return '0000:79:10.2'
+        def test_get_pci_address(ifname):
+            if ifname == "sriov:em1:1":
+                return "0000:79:10.1"
+            elif ifname == "sriov:em2:1":
+                return "0000:79:10.2"
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         bond = objects.object_from_json(json.loads(data))
@@ -1350,6 +1351,7 @@ class TestLinuxBond(base.TestCase):
         self.assertListEqual(vf_final, vf_map)
 
     def test_linux_bond_with_vf_param_provided(self):
+        common.set_noop(False)
         data = """{
 "type": "linux_bond",
 "name": "bond1",
@@ -1395,15 +1397,15 @@ class TestLinuxBond(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
-            if ifname == 'em1_1':
-                return '0000:79:10.1'
-            elif ifname == 'em2_1':
-                return '0000:79:10.2'
+        def test_get_pci_address(ifname):
+            if ifname == "sriov:em1:1":
+                return "0000:79:10.1"
+            elif ifname == "sriov:em2:1":
+                return "0000:79:10.2"
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         objects.object_from_json(json.loads(data))
@@ -2136,12 +2138,12 @@ class TestSriovVF(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
         data = '{"type": "sriov_vf", "device": "em1", "vfid": 0}'
         vf = objects.object_from_json(json.loads(data))
@@ -2153,12 +2155,12 @@ class TestSriovVF(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
         data = '{"type": "sriov_vf", "device": "em1", "vfid": "0"}'
         err = self.assertRaises(objects.InvalidConfigException,
@@ -2172,12 +2174,12 @@ class TestSriovVF(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
         data = '{"type": "sriov_vf", "device": "em1"}'
         err = self.assertRaises(objects.InvalidConfigException,
@@ -2191,12 +2193,12 @@ class TestSriovVF(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
         data = '{"type": "sriov_vf", "device": "em1", "vfid": 16,' \
                '"use_dhcp": false}'
@@ -2210,12 +2212,12 @@ class TestSriovVF(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
         data = '{"type": "sriov_vf", "device": "em1", "vfid": 16,' \
                '"use_dhcp": false, "name": "em1_7"}'
@@ -2229,12 +2231,12 @@ class TestSriovVF(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         data = '{"type": "sriov_vf", "device": "em4", "vfid": 16,' \
@@ -2258,12 +2260,12 @@ class TestSriovVF(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         data = '{"type": "sriov_vf", "device": "em4", "vfid": 16,' \
@@ -2287,12 +2289,12 @@ class TestSriovVF(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         data = '{"type": "sriov_vf", "device": "em4", "vfid": 16,' \
@@ -2309,12 +2311,12 @@ class TestSriovVF(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         data = '{"type": "sriov_vf", "device": "em4", "vfid": 16,' \
@@ -2330,12 +2332,12 @@ class TestSriovVF(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
 
         def dummy_mapped_nics(nic_mapping=None):
@@ -2355,18 +2357,13 @@ class TestSriovVF(base.TestCase):
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
 
-        def test_get_pci_address(ifname, noop):
-            return None
-
-        def test_get_stored_pci_address(ifname, noop):
+        def test_get_pci_address(ifname):
             return '0000:79:10.2'
 
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
-        self.stub_out('os_net_config.utils.get_pci_address',
+        self.stub_out('os_net_config.common.get_pci_address',
                       test_get_pci_address)
-        self.stub_out('os_net_config.utils.get_stored_pci_address',
-                      test_get_stored_pci_address)
         data = '{"type": "sriov_vf", "device": "em1", "vfid": 16,' \
                '"use_dhcp": false}'
         vf = objects.object_from_json(json.loads(data))


### PR DESCRIPTION
Presently the PCI address is read using ethtool command, when the device is bound with standard netdev driver. It is fetched from dpdk map when its bound with vfio-pci. The caller is expected to identify the device type and choose the appropriate function. The get_pci_address(interface_name) will now handle fetching the PCI address of the interface irrespective of the device types. In addition to that, now the PCI address of the SR-IOV VFs also could be fetched by passing the interface name in the format f"sriov:{pf_name}:{vfid}". With the usage of sysfs, the name of sriov vf is not required to fetch the pci address. This will be used in nic partitioning use cases when sriov_drivers_autoprobe is disabled.


(cherry picked from commit d268100293fb82e11597ff5945a01d6473b204a9)