### PR TITLE
sriov: add pci address and mac address in sriov map

### DIFF
--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -1115,7 +1115,9 @@ class LinuxBond(_BaseOpts):
                                           steering_mode=member.steering_mode,
                                           link_mode=member.link_mode,
                                           vdpa=member.vdpa,
-                                          lag_candidate=True)
+                                          lag_candidate=True,
+                                          pci_address=member.pci_address,
+                                          mac_address=member.mac_address)
             if isinstance(member, SriovVF):
                 LinuxBond.update_vf_config(member)
             member.linux_bond_name = name
@@ -1699,13 +1701,17 @@ class SriovPF(_BaseOpts):
         self.ethtool_opts = ethtool_opts
         self.vdpa = vdpa
         self.steering_mode = steering_mode
+        self.pci_address = common.get_pci_address(self.name)
+        self.mac_address = common.interface_mac(self.name)
         noop = common.get_noop()
         utils.update_sriov_pf_map(self.name, self.numvfs, noop,
                                   promisc=self.promisc,
                                   link_mode=self.link_mode,
                                   vdpa=self.vdpa,
                                   drivers_autoprobe=self.drivers_autoprobe,
-                                  steering_mode=self.steering_mode)
+                                  steering_mode=self.steering_mode,
+                                  pci_address=self.pci_address,
+                                  mac_address=self.mac_address)
 
     @staticmethod
     def get_on_off(config):

--- a/os_net_config/tests/test_cli.py
+++ b/os_net_config/tests/test_cli.py
@@ -32,6 +32,14 @@ SAMPLE_BASE = os.path.join(REALPATH, '../../', 'etc',
                            'os-net-config', 'samples')
 
 
+def generate_random_mac(name):
+    # Generate 6 random bytes
+    mac = [random.randint(0, 255) for _ in range(6)]
+    mac[0] &= 0xFE
+    mac_address = ':'.join(f'{byte:02x}' for byte in mac)
+    return mac_address
+
+
 class TestCli(base.TestCase):
 
     def setUp(self):
@@ -41,16 +49,20 @@ class TestCli(base.TestCase):
         common._LOG_FILE = '/tmp/' + rand + 'os_net_config.log'
         sys.stdout = StringIO()
         sys.stderr = StringIO()
+        self.stub_out('os_net_config.common.interface_mac',
+                      generate_random_mac)
 
         def stub_is_ovs_installed():
             return True
         self.stub_out('os_net_config.utils.is_ovs_installed',
                       stub_is_ovs_installed)
 
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
-                                     drivers_autoprobe=True,
+        def test_update_sriov_pf_map(ifname, numvfs, noop, promisc=None,
                                      link_mode='legacy', vdpa=False,
-                                     steering_mode="smfs"):
+                                     steering_mode=None,
+                                     lag_candidate=None,
+                                     drivers_autoprobe=True,
+                                     pci_address=None, mac_address=None):
             return
         self.stub_out('os_net_config.utils.update_sriov_pf_map',
                       test_update_sriov_pf_map)

--- a/os_net_config/tests/test_objects.py
+++ b/os_net_config/tests/test_objects.py
@@ -24,6 +24,14 @@ from os_net_config import objects
 from os_net_config.tests import base
 
 
+def generate_random_mac(name):
+    # Generate 6 random bytes
+    mac = [random.randint(0, 255) for _ in range(6)]
+    mac[0] &= 0xFE
+    mac_address = ':'.join(f'{byte:02x}' for byte in mac)
+    return mac_address
+
+
 class TestRoute(base.TestCase):
     def setUp(self):
         super(TestRoute, self).setUp()
@@ -1984,11 +1992,14 @@ class TestSriovPF(base.TestCase):
     def setUp(self):
         super(TestSriovPF, self).setUp()
         common.set_noop(True)
+        self.stub_out('os_net_config.common.interface_mac',
+                      generate_random_mac)
 
-        def test_update_sriov_pf_map(name, numvfs, noop, promisc=None,
+        def test_update_sriov_pf_map(ifname, numvfs, noop, promisc=None,
                                      link_mode='legacy', vdpa=False,
-                                     drivers_autoprobe=True,
-                                     steering_mode="smfs"):
+                                     steering_mode=None, lag_candidate=None,
+                                     drivers_autoprobe=True, pci_address=None,
+                                     mac_address=None):
             return
         self.stub_out('os_net_config.utils.update_sriov_pf_map',
                       test_update_sriov_pf_map)

--- a/os_net_config/tests/test_utils.py
+++ b/os_net_config/tests/test_utils.py
@@ -151,13 +151,17 @@ class TestUtils(base.TestCase):
             return 0
         self.stub_out('os_net_config.sriov_config.get_numvfs',
                       get_numvfs_stub)
-        utils.update_sriov_pf_map('eth1', 10, False)
+        utils.update_sriov_pf_map("eth1", 10, False,
+                                  pci_address="0000:8a:07.1",
+                                  mac_address="AA:BB:CC:DD:EE:FF")
         contents = common.get_file_data(common.SRIOV_CONFIG_FILE)
         sriov_pf_map = yaml.safe_load(contents) if contents else []
         self.assertEqual(1, len(sriov_pf_map))
         test_sriov_pf_map = [{'device_type': 'pf', 'link_mode': 'legacy',
                               'drivers_autoprobe': True,
-                              'name': 'eth1', 'numvfs': 10, 'vdpa': False}]
+                              'name': 'eth1', 'numvfs': 10, 'vdpa': False,
+                              "pci_address": "0000:8a:07.1",
+                              "mac_address": "AA:BB:CC:DD:EE:FF"}]
         self.assertListEqual(test_sriov_pf_map, sriov_pf_map)
 
     def test_update_sriov_pf_map_with_same_numvfs(self):


### PR DESCRIPTION
SR-IOV PF's pci address and mac address shall be stored in the map, so that when the PF is attached to the guest, the PF's details coud be read.


(cherry picked from commit 95cc760022d0a6d92eea5bc81ef24cd4f4c7363e)