### PR TITLE
doc: update readme description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ ChangeLog
 
 # Visual Studio Code
 .vscode
+
+# Leftovers from other commands like tox -e pep8,tht
+.cache

--- a/README.rst
+++ b/README.rst
@@ -2,17 +2,14 @@
 os-net-config
 =============
 
-Team and repository tags
-------------------------
-
-.. image:: https://governance.openstack.org/tc/badges/os-net-config.svg
-    :target: https://governance.openstack.org/tc/reference/tags/index.html
+A declarative network configuration tool for hosts.
 
 Overview
 --------
 
 ``os-net-config`` is a host network configuration tool which supports multiple
-backend configuration providers.
+backend configuration providers. One of: ifcfg (network-init-scripts), 
+nmstate (NetworkManager), or eni (basic support for /etc/network/interfaces)
 
 * Documentation: https://docs.openstack.org/os-net-config/latest
 * Source: https://opendev.org/openstack/os-net-config
@@ -33,4 +30,29 @@ project consists of:
   at /etc/os-net-config/config.yaml. This can be customized via the
   --config-file CLI option.
 
+* The provider used by os-net-config, which can be customized via a flag
+  Try "os-net-config --help" for a list of supported PROVIDERs.
+
 * A python library which provides configuration via an object model.
+
+* A set of related services like os-net-config-sriov, os-net-config-sriov-bind,
+  os-net-config-dcb.
+
+* Configuration examples could be found at
+  https://github.com/os-net-config/os-net-config/tree/master/etc/os-net-config/samples
+
+Contributing
+------------
+
+See `CONTRIBUTING.rst`__.
+
+__ https://github.com/os-net-config/os-net-config/blob/master/CONTRIBUTING.rst
+
+Installation
+------------
+
+* RPM based
+  os-net-config is part of Openstack RHEL8+, you may install it using 'sudo yum install os-net-config'
+
+* From source code
+  Use git to download source and then 'cd os-net-confg', 'python setup.py install --prefix=/usr'

--- a/bindep.txt
+++ b/bindep.txt
@@ -1,6 +1,12 @@
 # This is a cross-platform list tracking distribution packages needed for
 # install and tests;
-# see https://docs.openstack.org/infra/bindep/ for additional information.
+# It also facilitates OpenStack-CI package installation
+# before the execution of any tests.
+#
+# See the following for details:
+#  - https://docs.openstack.org/infra/bindep/
+#  - https://opendev.org/opendev/bindep/
+# for additional information.
 
 ethtool
 nmstate            [platform:rpm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ description-file =
 author = OpenStack
 author-email = openstack-discuss@lists.openstack.org
 license = Apache License (2.0)
-home-page = https://opendev.org/openstack/os-net-config
+home_page = https://github.com/os-net-config/os-net-config
 python-requires = >=3.6
 classifier =
     Environment :: OpenStack
@@ -25,6 +25,8 @@ classifier =
 [files]
 packages =
     os_net_config
+data_files =
+    site-packages/os_net_config = os-net-config/*
 
 [entry_points]
 console_scripts =


### PR DESCRIPTION
This commit is to update readme content related to os-net-config repo
* Correct reference to invalid urls
* Added more description for os-net-config feature

Closes: https://issues.redhat.com/browse/osprh-8784

Conflicts:
    README.rst
    setup.cfg


(cherry picked from commit 102cf4b324e931551485857b9e052afb3d0ad41e)