### PR TITLE
sriov: failure in parsing sriov_map

### DIFF
--- a/os_net_config/utils.py
+++ b/os_net_config/utils.py
@@ -199,14 +199,14 @@ def _ordered_nics(check_active):
         )
     pfs = common.get_sriov_pfs()
     for pf in pfs:
-        if _is_embedded_nic(pf):
-            logger.info("%s: an embedded nic configured as PF", nic)
-            if pf not in embedded_nics:
-                embedded_nics.append(nic)
+        if _is_embedded_nic(pf["name"]):
+            logger.info("%s: an embedded nic configured as PF", pf["name"])
+            if pf["name"] not in embedded_nics:
+                embedded_nics.append(pf["name"])
         else:
-            logger.info("%s: SR-IOV configured nic", nic)
-            if pf not in nics:
-                nics.append(pf)
+            logger.info("%s: SR-IOV configured nic", pf["name"])
+            if pf["name"] not in nics:
+                nics.append(pf["name"])
 
     # NOTE: we could just natural sort all active devices,
     # but this ensures em, eno, and eth are ordered first


### PR DESCRIPTION
The parsing of the sriov_map added recently in _ordered_nics() created a regression. The pf dict is wrongly used instead of the pf["name"], which resulted in the regression.


(cherry picked from commit 5ff3b7c19e8a0bc5280ff72d7c500d3facde51ac)