### PR TITLE
iprules: ignore defined ip rules

### DIFF
--- a/os_net_config/tests/test_impl_nmstate.py
+++ b/os_net_config/tests/test_impl_nmstate.py
@@ -2756,6 +2756,7 @@ class TestNmstateNetConfigApply(base.TestCase):
     def setUp(self):
         super(TestNmstateNetConfigApply, self).setUp()
         common.set_noop(True)
+        impl_nmstate.CONFIG_RULES_FILE = "/tmp/nmstate_files/rules.yaml"
 
         def test_iface_state(iface_data='', verify_change=True):
             # This function returns None


### PR DESCRIPTION
If the IP rules are not defined by NetworkManager, os-net-config will be unable to remove them, resulting in a Verification Error. With this pull request, os-net-config record the rules set by os-net-config and will ignore other rules set on host


(cherry picked from commit 482b6300f0a443c8888ca43aeb59c030150828c0)