### PR TITLE
schema: route schema shall support nexthop and next_hop

### DIFF
--- a/os_net_config/schema.yaml
+++ b/os_net_config/schema.yaml
@@ -168,12 +168,15 @@ definitions:
 
     route:
         type: object
-        oneOf:
-        - properties:
+        properties:
             next_hop:
-              oneOf:
-                - $ref: "#/definitions/ip_address_string_or_param"
-                - $ref: "#/definitions/self_interface"
+                oneOf:
+                    - $ref: "#/definitions/ip_address_string_or_param"
+                    - $ref: "#/definitions/self_interface"
+            nexthop:
+                oneOf:
+                    - $ref: "#/definitions/ip_address_string_or_param"
+                    - $ref: "#/definitions/self_interface"
             ip_netmask:
                 $ref: "#/definitions/ip_cidr_string_or_param"
             default:
@@ -186,27 +189,23 @@ definitions:
                     - $ref: "#/definitions/int_or_param"
             metric:
                 $ref: "#/definitions/int_or_param"
-          requires:
-            - next_hop
-          additionalProperties: False
-        - properties:
-            nexthop:
-                $ref: "#/definitions/ip_address_string_or_param"
             destination:
                 $ref: "#/definitions/ip_cidr_string_or_param"
-            default:
-                $ref: "#/definitions/bool_or_param"
-            route_options:
-                $ref: "#/definitions/string_or_param"
-            table:
-                anyOf:
-                    - $ref: "#/definitions/string_or_param"
-                    - $ref: "#/definitions/int_or_param"
-            metric:
-                $ref: "#/definitions/int_or_param"
-          requires:
-            - nexthop
-          additionalProperties: False
+        allOf:
+            - anyOf:
+                - required:
+                    - default
+                - oneOf:
+                    - required:
+                        - destination
+                    - required:
+                        - ip_netmask
+            - oneOf:
+                - required:
+                    - next_hop
+                - required:
+                    - nexthop
+        additionalProperties: False
     list_of_route:
         type: array
         items:

--- a/os_net_config/tests/test_validator.py
+++ b/os_net_config/tests/test_validator.py
@@ -209,16 +209,16 @@ class TestDerivedTypes(base.TestCase):
                 "default": True, "route_options": "metric 10"}
         self.assertTrue(v.is_valid(data))
 
-        # Validation fails unless only os-net-config or neutron schema.
-        # os-net-config :: ip_netmask  + next_hop
-        # neutron       :: destination + nexthop
         data = {"next_hop": "172.19.0.1", "destination": "172.19.0.0/24"}
-        self.assertFalse(v.is_valid(data))
+        self.assertTrue(v.is_valid(data))
         data = {"nexthop": "172.19.0.1", "ip_netmask": "172.19.0.0/24"}
-        self.assertFalse(v.is_valid(data))
+        self.assertTrue(v.is_valid(data))
+
+        # negative test cases - destination and ip_netmask together
         data = {"nexthop": "172.19.0.1", "destination": "172.19.0.0/24",
                 "ip_netmask": "172.19.0.0/24"}
         self.assertFalse(v.is_valid(data))
+        # negative test cases - next_hop and nexthop together
         data = {"next_hop": "172.19.0.1", "nexthop": "172.19.0.1",
                 "destination": "172.19.0.0/24"}
         self.assertFalse(v.is_valid(data))


### PR DESCRIPTION
The current route schema requires `next_hop` when `ip_netmask` is configured and `nexthop` when `destination` is configured. But since the schema validation is ignored until recently and the object parser parses both `nexthop` and `next_hop` alike, the schema validation failure for the same did not fail os-net-config. Now the schema for `route` object is modified to support both `nexthop` and `next_hop` and hence the schema validation will not fail on existing deployments for the same.


(cherry picked from commit 1147937778cad911bddc941d939beafad4da6ce2)