### PR TITLE
sriov: sriov: unit tests fails while accessing sriov_config.py

### DIFF
--- a/os_net_config/tests/test_impl_nmstate.py
+++ b/os_net_config/tests/test_impl_nmstate.py
@@ -221,6 +221,8 @@ class TestNmstateNetConfig(base.TestCase):
     def setUp(self):
         super(TestNmstateNetConfig, self).setUp()
         common.set_noop(True)
+        common.DPDK_MAPPING_FILE = '/tmp/dpdk_mapping.yaml'
+        common.SRIOV_CONFIG_FILE = '/tmp/sriov_config.yaml'
 
         self.stub_out("os_net_config.common.interface_mac",
                       generate_random_mac)
@@ -285,6 +287,13 @@ class TestNmstateNetConfig(base.TestCase):
             return
         self.stub_out('os_net_config.utils.bind_dpdk_interfaces',
                       test_bind_dpdk_interfaces)
+
+    def tearDown(self):
+        super(TestNmstateNetConfig, self).tearDown()
+        if os.path.isfile(common.SRIOV_CONFIG_FILE):
+            os.remove(common.SRIOV_CONFIG_FILE)
+        if os.path.isfile(common.DPDK_MAPPING_FILE):
+            os.remove(common.DPDK_MAPPING_FILE)
 
     def get_running_info(self, yaml_file):
         with open(yaml_file) as f:

--- a/os_net_config/tests/test_objects.py
+++ b/os_net_config/tests/test_objects.py
@@ -2003,6 +2003,12 @@ class TestSriovPF(base.TestCase):
             return
         self.stub_out('os_net_config.utils.update_sriov_pf_map',
                       test_update_sriov_pf_map)
+        common.SRIOV_CONFIG_FILE = '/tmp/sriov_config.yaml'
+
+    def tearDown(self):
+        super(TestSriovPF, self).tearDown()
+        if os.path.isfile(common.SRIOV_CONFIG_FILE):
+            os.remove(common.SRIOV_CONFIG_FILE)
 
     def test_from_json_numvfs(self):
         data = '{"type": "sriov_pf", "name": "em1", "numvfs": 16,' \
@@ -2140,10 +2146,14 @@ class TestSriovVF(base.TestCase):
 
     def setUp(self):
         super(TestSriovVF, self).setUp()
+        common.SRIOV_CONFIG_FILE = '/tmp/sriov_config.yaml'
+
         common.set_noop(True)
 
     def tearDown(self):
         super(TestSriovVF, self).tearDown()
+        if os.path.isfile(common.SRIOV_CONFIG_FILE):
+            os.remove(common.SRIOV_CONFIG_FILE)
 
     def test_from_json_zero_vfid(self):
         def test_get_vf_devname(device, vfid):

--- a/os_net_config/tests/test_sriov_config.py
+++ b/os_net_config/tests/test_sriov_config.py
@@ -58,6 +58,8 @@ class TestSriovConfig(base.TestCase):
         super(TestSriovConfig, self).tearDown()
         if os.path.isfile(common._LOG_FILE):
             os.remove(common._LOG_FILE)
+        if os.path.isfile(sriov_config._UDEV_RULE_FILE):
+            os.remove(sriov_config._UDEV_RULE_FILE)
         if os.path.isfile(common.SRIOV_CONFIG_FILE):
             os.remove(common.SRIOV_CONFIG_FILE)
         if os.path.isfile(sriov_config._IFUP_LOCAL_FILE):
@@ -69,6 +71,8 @@ class TestSriovConfig(base.TestCase):
             os.remove(sriov_config._ALLOCATE_VFS_FILE)
         if os.path.isfile(sriov_config._UDEV_LEGACY_RULE_FILE):
             os.remove(sriov_config._UDEV_LEGACY_RULE_FILE)
+        if os.path.isfile(sriov_config._REP_LINK_NAME_FILE):
+            os.remove(sriov_config._REP_LINK_NAME_FILE)
 
     def _write_numvfs(self, ifname, numvfs=0, autoprobe=True):
         os.makedirs(common.get_dev_path(ifname, '_device'))


### PR DESCRIPTION
The unit tests fails while accessing /var/lib/os-net-config/sriov_config.yaml. Also the temporary files corresponding to sriov_config.yaml, rep-link-name.sh 80-persistent-os-net-config.rules are removed during tearDown()