### PR TITLE
cleanup: stop blindly removing nmconnection files

### DIFF
--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -19,7 +19,6 @@ import itertools
 import logging
 import netaddr
 import os
-from pathlib import Path
 import re
 import shutil
 
@@ -98,10 +97,6 @@ def route_table_config_path():
 
 def cleanup_pattern():
     return "/etc/sysconfig/network-scripts/ifcfg-*"
-
-
-def nm_cleanup_pattern():
-    return "/etc/NetworkManager/system-connections/*.nmconnection"
 
 
 def dhclient_path():
@@ -1998,12 +1993,6 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                         )
                         self.ifdown(interface_name)
                         self.remove_config(ifcfg_file)
-            for nmconn_file in glob.iglob(nm_cleanup_pattern()):
-                interface_name = Path(nmconn_file).stem
-                cmd = ['nmcli', 'connection', 'delete', interface_name]
-                msg = f"{interface_name}: Removing nm connection"
-                self.execute(msg, *cmd)
-                self.remove_config(nmconn_file)
 
         if activate:
             for interface in apply_interfaces:

--- a/os_net_config/tests/test_impl_ifcfg.py
+++ b/os_net_config/tests/test_impl_ifcfg.py
@@ -2318,7 +2318,6 @@ class TestIfcfgNetConfigApply(base.TestCase):
         self.temp_rule_file = tempfile.NamedTemporaryFile()
         self.temp_bridge_file = tempfile.NamedTemporaryFile()
         self.temp_cleanup_file = tempfile.NamedTemporaryFile(delete=False)
-        self.temp_cleanup_nm_file = tempfile.NamedTemporaryFile(delete=False)
         self.ifup_interface_names = []
         self.ovs_appctl_cmds = []
         self.stop_dhclient_interfaces = []
@@ -2370,11 +2369,6 @@ class TestIfcfgNetConfigApply(base.TestCase):
         self.stub_out('os_net_config.impl_ifcfg.cleanup_pattern',
                       test_cleanup_pattern)
 
-        def test_nm_cleanup_pattern():
-            return self.temp_cleanup_nm_file.name
-        self.stub_out('os_net_config.impl_ifcfg.nm_cleanup_pattern',
-                      test_nm_cleanup_pattern)
-
         def test_stop_dhclient_process(interface):
             self.stop_dhclient_interfaces.append(interface)
         self.stub_out('os_net_config.impl_ifcfg.stop_dhclient_process',
@@ -2405,9 +2399,6 @@ class TestIfcfgNetConfigApply(base.TestCase):
         self.temp_bridge_file.close()
         if os.path.exists(self.temp_cleanup_file.name):
             self.temp_cleanup_file.close()
-        if os.path.exists(self.temp_cleanup_nm_file.name):
-            self.temp_cleanup_nm_file.close()
-
         super(TestIfcfgNetConfigApply, self).tearDown()
 
     def test_route_table_apply(self):
@@ -2895,7 +2886,6 @@ class TestIfcfgNetConfigApply(base.TestCase):
     def test_cleanup(self):
         self.provider.apply(cleanup=True)
         self.assertTrue(not os.path.exists(self.temp_cleanup_file.name))
-        self.assertTrue(not os.path.exists(self.temp_cleanup_nm_file.name))
 
     def test_cleanup_not_loopback(self):
         tmp_lo_file = '%s-lo' % self.temp_cleanup_file.name


### PR DESCRIPTION
Stops removing NetworkManager connections from the ifcfg provider. The logic in the NetworkManager cleanup is too indiscriminate and can cause removal of connections that don't need to be removed, should not be removed, and/or can cause spurious errors. A follow-up patch will
ensure there are no conflicts in a safe way that allows for peaceful co-existence of network-scripts and nmstate.

Suggested-by: Karthik Sundaravel <ksundara@redhat.com>
Signed-off-by: Dan Sneddon <dsneddon@redhat.com>
Fixes:  https://issues.redhat.com/browse/OSPRH-15443