### PR TITLE
migrate: add utils to destroy dpdk ports

### DIFF
--- a/os_net_config/common.py
+++ b/os_net_config/common.py
@@ -508,6 +508,22 @@ def wait_for_vf_driver_binding(pf, vfs, req_driver):
                 )
 
 
+def unset_driverctl_override(pci_address):
+    cmd = ["driverctl", "unset-override", pci_address]
+    try:
+        logger.info("%s: running %s", pci_address, " ".join(cmd))
+        out, err = processutils.execute(*cmd)
+        if err:
+            logger.error("%s: Failed to unbind dpdk interface.", pci_address)
+            return 1
+        return 0
+    except processutils.ProcessExecutionError as exc:
+        logger.error(
+            "%s: Failed to bind interface with dpdk. %s", pci_address, exc
+        )
+        return 1
+
+
 def set_driverctl_override(pci_address, driver):
     if driver is None:
         logger.info("%s: Driver override is not required.", pci_address)

--- a/os_net_config/utils.py
+++ b/os_net_config/utils.py
@@ -236,6 +236,18 @@ def update_dpdk_map(ifname, driver):
         _update_dpdk_map(ifname, pci_address, mac_address, driver)
 
 
+def unbind_dpdk_interfaces(pci_address):
+    iface_driver = common.get_pci_device_driver(pci_address)
+    if iface_driver == "vfio-pci":
+        return common.unset_driverctl_override(pci_address)
+    else:
+        logger.info(
+            "%s: not bound with vfio-pci and hence not removing the override",
+            pci_address,
+        )
+        return 0
+
+
 def bind_dpdk_interfaces(ifname, driver, noop):
     if common.is_mellanox_interface(ifname) and 'vfio-pci' in driver:
         msg = ("For Mellanox NIC %s, the default driver vfio-pci "
@@ -284,6 +296,40 @@ def bind_dpdk_interfaces(ifname, driver, noop):
         # available nor bound with dpdk.
         msg = "Interface %s cannot be found" % ifname
         raise common.OvsDpdkBindException(msg)
+
+
+def remove_dpdk_interface(iface):
+    dpdk_map = common.get_dpdk_map()
+    for dpdk_nic in dpdk_map:
+        if dpdk_nic["name"] == iface:
+            err = detach_dpdk_interfaces(dpdk_nic["pci_address"])
+            if err:
+                logger.warning(
+                    "%s: Failed to detach dpdk interface",
+                    dpdk_nic["name"],
+                )
+            err = unbind_dpdk_interfaces(dpdk_nic["pci_address"])
+            if err:
+                logger.error(
+                    "%s: Failed to unbind dpdk interface",
+                    dpdk_nic["name"],
+                )
+            break
+    else:
+        logger.error("%s: could not find in dpdk_mapping.yaml", iface)
+
+
+def detach_dpdk_interfaces(pci_address):
+    cmd = ["ovs-appctl", "netdev-dpdk/detach", pci_address]
+    try:
+        logger.info("%s: running %s", pci_address, " ".join(cmd))
+        out, err = processutils.execute(*cmd)
+        if err:
+            return 1
+        return 0
+    except processutils.ProcessExecutionError as exc:
+        logger.error("%s: Failed to detach. Err: %s", pci_address, exc)
+        return -1
 
 
 def translate_ifname_to_pci_address(ifname, noop):


### PR DESCRIPTION
Add utility methods to detach the dpdk ports from ovs and unset the
driver overrides configured for the dpdk ports.