### PR TITLE
cli: add new flag to support clean_all nm conn

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -132,6 +132,13 @@ def parse_opts(argv):
              "(WARNING, permanently renames nics).",
         required=False)
 
+    parser.add_argument(
+        '--nm-cleanup',
+        dest="nm_cleanup",
+        action='store_true',
+        help="Cleanup existing nm connection for active interfaces.",
+        required=False)
+
     opts = parser.parse_args(argv[1:])
 
     return opts
@@ -390,6 +397,7 @@ def main(argv=sys.argv, main_logger=None):
         if configure_sriov:
             pf_files_changed = provider.apply(cleanup=opts.cleanup,
                                               activate=not opts.no_activate,
+                                              nmcleanup=opts.nm_cleanup,
                                               config_rules_dns=False)
 
             if opts.provider == 'ifcfg' and not opts.noop:
@@ -421,6 +429,7 @@ def main(argv=sys.argv, main_logger=None):
             utils.configure_sriov_vfs()
 
         files_changed = provider.apply(cleanup=opts.cleanup,
+                                       nmcleanup=opts.nm_cleanup,
                                        activate=not opts.no_activate)
         logger.info(
             "Succesfully applied the network configuration with "


### PR DESCRIPTION
When os-net-config-sriov is run after RHOSO node-prov with VLAN interface using cloud-init, there will be nm connections.
This needs to be cleaned, if ifcfg provider is used

Closes: https://issues.redhat.com/browse/OSPRH-16526