### PR TITLE
logs: remove logging errors for sriov vf

### DIFF
--- a/os_net_config/common.py
+++ b/os_net_config/common.py
@@ -444,12 +444,12 @@ def get_default_vf_driver(pf_name, vfid):
         out, err = processutils.execute(*cmd)
         kernel_driver = out.strip()
         logger.info(
-            "%s-%d: default vf driver is %s", pf_name, vfid, kernel_driver
+            "%s-%s: default vf driver is %s", pf_name, vfid, kernel_driver
         )
         return kernel_driver
     except (OSError, processutils.ProcessExecutionError) as e:
         logger.error(
-            "%s-%d: failed to get default vf driver: %s", pf_name, vfid, e
+            "%s-%s: failed to get default vf driver: %s", pf_name, vfid, e
         )
         return None
 
@@ -470,12 +470,12 @@ def wait_for_vf_driver_binding(pf, vfs, req_driver):
         for i in range(30):
             driver = get_pci_device_driver(pci_address)
             if driver == req_driver:
-                logger.info("%s-%d: verified binding with %s", pf, vf, driver)
+                logger.info("%s-%s: verified binding with %s", pf, vf, driver)
                 break
             time.sleep(1)
         else:
             logger.error(
-                "%s-%d: bound with %s instead of %s",
+                "%s-%s: bound with %s instead of %s",
                 pf,
                 vf,
                 driver,
@@ -489,7 +489,7 @@ def wait_for_vf_driver_binding(pf, vfs, req_driver):
                 time.sleep(1)
             else:
                 logger.warning(
-                    "%s-%d: device path %s is not available yet",
+                    "%s-%s: device path %s is not available yet",
                     pf,
                     vf,
                     vf_path,

--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -1271,7 +1271,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         :param sriov_vf: The SriovVF object to add
         """
         logger.info(
-            "%s-%d: adding sriov vf: %s",
+            "%s-%s: adding sriov vf: %s",
             sriov_vf.device,
             sriov_vf.vfid,
             sriov_vf.name,
@@ -1290,7 +1290,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         :param sriov_vf: The SriovVF object to be deleted
         """
         logger.info(
-            "%s-%d: Deleting sriov vf: %s",
+            "%s-%s: Deleting sriov vf: %s",
             sriov_vf.device,
             sriov_vf.vfid,
             sriov_vf.name,

--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -461,7 +461,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
         """
         if sriov_vf.device in self.sriov_vf_data:
             logger.info(
-                "%s-%d: Updating VF, Trust: %s "
+                "%s-%s: Updating VF, Trust: %s "
                 "Spoofcheck: %s Vlan: %d Qos: %d "
                 "Min Rate: %d Max Rate: %d",
                 sriov_vf.device, sriov_vf.vfid,
@@ -2270,7 +2270,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
 
         vf_config = self.get_vf_config(sriov_vf)
         logger.debug(
-            "%s-%d: vf config %s", sriov_vf.device, sriov_vf.vfid, vf_config
+            "%s-%s vf config %s", sriov_vf.device, sriov_vf.vfid, vf_config
         )
 
         self.sriov_vf_data[sriov_vf.device][sriov_vf.vfid] = vf_config
@@ -2286,7 +2286,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
         if self.migration_enabled:
             self._clean_iface(sriov_vf.name, InterfaceType.ETHERNET)
 
-        logger.info("%s-%d: adding vf", sriov_vf.device, sriov_vf.vfid)
+        logger.info("%s-%s: adding vf", sriov_vf.device, sriov_vf.vfid)
         data = self._add_common(sriov_vf)
         data[Interface.TYPE] = InterfaceType.ETHERNET
         data[Ethernet.CONFIG_SUBTREE] = {}

--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -742,21 +742,21 @@ class OvsBridge(_BaseOpts):
     def update_vf_config(iface):
         if iface.trust is None:
             logger.info(
-                "%s-%d: Trust is not set, defaulting to on",
+                "%s-%s: Trust is not set, defaulting to on",
                 iface.device,
                 iface.vfid
             )
             iface.trust = "on"
         if iface.spoofcheck is None:
             logger.info(
-                "%s-%d: Spoofcheck is not set, defaulting to off",
+                "%s-%s: Spoofcheck is not set, defaulting to off",
                 iface.device,
                 iface.vfid
             )
             iface.spoofcheck = "off"
         if iface.promisc is None:
             logger.info(
-                "%s-%d: Promisc is not set, defaulting to on",
+                "%s-%s: Promisc is not set, defaulting to on",
                 iface.device,
                 iface.vfid
             )
@@ -1134,21 +1134,21 @@ class LinuxBond(_BaseOpts):
     def update_vf_config(iface):
         if iface.trust is None:
             logger.info(
-                "%s-%d: Trust is not set, defaulting to on",
+                "%s-%s: Trust is not set, defaulting to on",
                 iface.device,
                 iface.vfid,
             )
             iface.trust = 'on'
         if iface.spoofcheck is None:
             logger.info(
-                "%s-%d: Spoofcheck is not set, defaulting to off",
+                "%s-%s: Spoofcheck is not set, defaulting to off",
                 iface.device,
                 iface.vfid,
             )
             iface.spoofcheck = 'off'
         if iface.promisc is None:
             logger.info(
-                "%s-%d: Promisc is not set, defaulting to off",
+                "%s-%s: Promisc is not set, defaulting to off",
                 iface.device,
                 iface.vfid,
             )
@@ -1231,21 +1231,21 @@ class OvsBond(_BaseOpts):
     def update_vf_config(iface):
         if iface.trust is None:
             logger.info(
-                "%s-%d: Trust is not set, defaulting to on",
+                "%s-%s: Trust is not set, defaulting to on",
                 iface.device,
                 iface.vfid,
             )
             iface.trust = "on"
         if iface.spoofcheck is None:
             logger.info(
-                "%s-%d: Spoofcheck is not set, defaulting to off",
+                "%s-%s: Spoofcheck is not set, defaulting to off",
                 iface.device,
                 iface.vfid,
             )
             iface.spoofcheck = "off"
         if iface.promisc is None:
             logger.info(
-                "%s-%d: Promisc is not set, defaulting to on",
+                "%s-%s: Promisc is not set, defaulting to on",
                 iface.device,
                 iface.vfid,
             )
@@ -1468,27 +1468,27 @@ class OvsDpdkPort(_BaseOpts):
     def update_vf_config(iface, driver=None):
         if iface.trust is None:
             logger.info(
-                "%s-%d: Trust is not set, defaulting to on",
+                "%s-%s: Trust is not set, defaulting to on",
                 iface.device,
                 iface.vfid,
             )
             iface.trust = "on"
         if iface.spoofcheck is None:
             logger.info(
-                "%s-%d: Spoofcheck is not set, defaulting to off",
+                "%s-%s: Spoofcheck is not set, defaulting to off",
                 iface.device,
                 iface.vfid,
             )
             iface.spoofcheck = "off"
         if iface.promisc is not None:
             logger.warning(
-                "%s-%d: Promisc can't be changed for ovs_dpdk_port",
+                "%s-%s: Promisc can't be changed for ovs_dpdk_port",
                 iface.device,
                 iface.vfid,
             )
             iface.promisc = None
         logger.info(
-            "%s-%d: Overriding the default driver for DPDK with %s",
+            "%s-%s: Overriding the default driver for DPDK with %s",
             iface.device,
             iface.vfid,
             driver,


### PR DESCRIPTION
The vfid of sriov vf is used as a string and integer and this resulted in logging errors. Now %s is used as format specifier to handle all the usages.