### PR TITLE
sriov: wait until driver is bound for NIC partitioning

### DIFF
--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -581,6 +581,24 @@ class NmstateNetConfig(os_net_config.NetConfig):
                         )
                         self.nmstate_apply(self.set_ifaces([pf_state]),
                                            verify=True)
+                        # NetworkManager-dispatcher scripts will bind the VFs
+                        # with the drivers. Wait for the completion of the
+                        # driver bindings.
+                        if linux_vfs:
+                            lnx_driver = common.get_default_vf_driver(
+                                pf, linux_vfs[0]
+                            )
+                            common.wait_for_vf_driver_binding(
+                                pf,
+                                linux_vfs,
+                                lnx_driver,
+                            )
+                        if dpdk_vfs:
+                            common.wait_for_vf_driver_binding(
+                                pf,
+                                dpdk_vfs,
+                                "vfio-pci",
+                            )
                         updated_pfs.append(pf_state["name"])
                 else:
                     logger.info(


### PR DESCRIPTION
When driverctl override is performed for VF with default drivers, it becomes necessary to wait until the sysfs for the VF device is available. Also when dispatcher scripts are used for binding the drivers, the main context is put to hold until the override happens.


(cherry picked from commit bcd8c353d1e2ed11e166426c0e592a9e17a5d316)