### PR TITLE
nmstate: avoid cleanup of ovs, sriov and other config.yaml interfaces

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -367,7 +367,8 @@ def main(argv=sys.argv, main_logger=None):
         # os-net-config skips the ifup <ifcfg-pfs>, since the ifcfgs for PFs
         # wouldn't have changed.
         if configure_sriov:
-            pf_files_changed = provider.apply(cleanup=opts.cleanup,
+            # Skip cleanup while applying PF configuration
+            pf_files_changed = provider.apply(cleanup=False,
                                               activate=not opts.no_activate,
                                               config_rules_dns=False)
 

--- a/os_net_config/common.py
+++ b/os_net_config/common.py
@@ -273,6 +273,18 @@ def get_sriov_pfs():
     return [pf for pf in sriov_map if pf["device_type"] == "pf"]
 
 
+def get_sriov_pf_names():
+    sriov_map = get_sriov_map()
+    return [pf['name'] for pf in sriov_map if pf["device_type"] == "pf"]
+
+
+def get_dpdk_iface_names():
+    contents = get_file_data(DPDK_MAPPING_FILE)
+    dpdk_map = yaml.safe_load(contents) if contents else []
+    iface_names = [item['name'] for item in dpdk_map]
+    return iface_names
+
+
 def _get_dpdk_mac_address(name):
     contents = get_file_data(DPDK_MAPPING_FILE)
     dpdk_map = yaml.safe_load(contents) if contents else []


### PR DESCRIPTION
The cleanup actions cannot be allowed on ovs interfaces, ovs bridges, SR-IOV devices and other interfaces defined in config.yaml. If there is a real need to remove these interfaces it would be recommended to re-configure the system again instead of cleanup.

Closes: https://issues.redhat.com/browse/OSPRH-17034

(cherry picked from commit 805ec05f8553d5d3b19c839b507b4c0779c0d9cf)