### PR TITLE
sriov: enable debug mode for sriov service

### DIFF
--- a/os_net_config/utils.py
+++ b/os_net_config/utils.py
@@ -37,7 +37,7 @@ Before=network-pre.target  openvswitch.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/os-net-config-sriov
+ExecStart=/usr/bin/os-net-config-sriov -d
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
Start the sriov service in debug mode to enable logging

Closes: https://issues.redhat.com/browse/OSPRH-17313

(cherry picked from commit dabb392041f41fd0b29fd8975ca8fc04d69690fc)