### PR TITLE
ifcfg: avoid bringing down of physical interfaces during cleanup

### DIFF
--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -2018,6 +2018,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
             utils.set_accept_ra_sysctl(interface, self.noop)
 
         if cleanup:
+            real_nics_to_restore = []
             for ifcfg_file in glob.iglob(cleanup_pattern()):
                 if ifcfg_file not in all_file_names:
                     interface_name = ifcfg_file[len(cleanup_pattern()) - 1:]
@@ -2027,6 +2028,27 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                         )
                         self.ifdown(interface_name)
                         self.remove_config(ifcfg_file)
+                        if (utils.is_real_nic(interface_name) and
+                                not common.is_vf_by_name(interface_name)):
+                            logger.info(
+                                "%s will be brought up after cleanup",
+                                interface_name
+                            )
+                            real_nics_to_restore.append(interface_name)
+
+            # During cleanup, physical interfaces not defined in the
+            # input YAML are brought DOWN. If they are not restored,
+            # subsequent configurations may fail due to changes in NIC
+            # numbering. This logic ensures real NICs are brought back
+            # UP to preserve consistent interface naming and avoid
+            # requiring changes to the YAML config.
+
+            for iface in real_nics_to_restore:
+                logger.info("%s: restoring real nic", iface)
+                data = self._add_common(objects.Interface(iface))
+                logger.debug("%s: generated ifcfg data \n%s", iface, data)
+                self.write_config(ifcfg_config_path(iface), data)
+                self.ifup(iface)
 
         if activate:
             for interface in apply_interfaces:


### PR DESCRIPTION
Changes are done to make a note of real nics during cleanup and restore the ifcfg and bring up the interface after cleanup.

Closes: https://issues.redhat.com/browse/OSPRH-17306

(cherry picked from commit c4d6f7f5de8e959843daa71763b230292d34224e)