### PR TITLE
schema: schema support for remove_config

### DIFF
--- a/os_net_config/schema.yaml
+++ b/os_net_config/schema.yaml
@@ -1,5 +1,5 @@
 ---
-$schema: http://json-schema.org/draft-04/schema
+$schema: "http://json-schema.org/draft-07/schema"
 
 definitions:
     # base types
@@ -146,6 +146,30 @@ definitions:
         items:
             $ref: "#/definitions/address"
         minItems: 1
+    device:
+        type: object
+        properties:
+            dev_name:
+                $ref: "#/definitions/string_or_param"
+            dev_type:
+              enum:
+                - "interface"
+                - "sriov_pf"
+                - "sriov_vf"
+                - "vlan"
+                - "ovs_bridge"
+                - "ovs_user_bridge"
+                - "ovs_bond"
+                - "ovs_patch_port"
+                - "ovs_tunnel"
+                - "ovs_dpdk_bond"
+                - "ovs_dpdk_port"
+                - "linux_bridge"
+                - "linux_bond"
+        required:
+          - dev_name
+          - dev_type
+        additionalProperties: False
     dscp2prio:
         type: object
         properties:
@@ -1645,8 +1669,9 @@ definitions:
         additionalProperties: False
 
 type: array
+minItems: 1
 items:
-    oneOf:
+  oneOf:
       - $ref: "#/definitions/interface"
       - $ref: "#/definitions/route_table"
       - $ref: "#/definitions/sriov_pf"
@@ -1674,4 +1699,65 @@ items:
       - $ref: "#/definitions/contrail_vrouter_dpdk"
       - $ref: "#/definitions/linux_tap"
       - $ref: "#/definitions/dcb_config"
-minItems: 1
+      - $ref: "#/definitions/device"
+allOf:
+  - if:
+      anyOf:
+        - contains:
+            $ref: "#/definitions/interface"
+        - contains:
+            $ref: "#/definitions/route_table"
+        - contains:
+            $ref: "#/definitions/sriov_pf"
+        - contains:
+            $ref: "#/definitions/sriov_vf"
+        - contains:
+            $ref: "#/definitions/vlan"
+        - contains:
+            $ref: "#/definitions/ovs_bridge"
+        - contains:
+            $ref: "#/definitions/ovs_user_bridge"
+        - contains:
+            $ref: "#/definitions/ovs_bond"
+        - contains:
+            $ref: "#/definitions/ovs_patch_port"
+        - contains:
+            $ref: "#/definitions/ovs_tunnel"
+        - contains:
+            $ref: "#/definitions/ovs_dpdk_bond"
+        - contains:
+            $ref: "#/definitions/ovs_dpdk_port"
+        - contains:
+            $ref: "#/definitions/linux_bridge"
+        - contains:
+            $ref: "#/definitions/linux_bond"
+        - contains:
+            $ref: "#/definitions/linux_team"
+        - contains:
+            $ref: "#/definitions/ivs_bridge"
+        - contains:
+            $ref: "#/definitions/ivs_interface"
+        - contains:
+            $ref: "#/definitions/nfvswitch_bridge"
+        - contains:
+            $ref: "#/definitions/nfvswitch_internal"
+        - contains:
+            $ref: "#/definitions/ib_interface"
+        - contains:
+            $ref: "#/definitions/ib_child_interface"
+        - contains:
+            $ref: "#/definitions/vpp_interface"
+        - contains:
+            $ref: "#/definitions/vpp_bond"
+        - contains:
+            $ref: "#/definitions/contrail_vrouter"
+        - contains:
+            $ref: "#/definitions/contrail_vrouter_dpdk"
+        - contains:
+            $ref: "#/definitions/linux_tap"
+        - contains:
+            $ref: "#/definitions/dcb_config"
+    then:
+      not:
+        contains:
+            $ref: "#/definitions/device"

--- a/os_net_config/validator.py
+++ b/os_net_config/validator.py
@@ -50,7 +50,7 @@ def validate_config(config, config_name="Config file"):
 
 def _validate_config(config, config_name, schema, filter_errors):
     error_messages = []
-    validator = jsonschema.Draft4Validator(schema)
+    validator = jsonschema.Draft7Validator(schema)
     v_errors = validator.iter_errors(config)
     v_errors = sorted(v_errors, key=lambda e: e.path)
     for v_error in v_errors:


### PR DESCRIPTION
Adding the schema support to handle remove_config. The `remove_device` schema shall be mutually exclusive with the other interface types and can not be used inside `network_config`.