### PR TITLE
[DNM]ci: use pending status for ci-gate label instead of failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
              github.event.action == 'unlabeled' || 
              github.event.action == 'synchronize') }}
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      contents: read
+      pull-requests: read
     steps:
       - name: Check for ci-passed label and ci-gate status
         uses: actions/github-script@v7
@@ -49,7 +53,21 @@ jobs:
             const hasGate = labelNames.includes('ci-gate');
 
             if (hasGate) {
-              core.setFailed("'ci-gate' - CI still in-progress");
+              // Set pending status using commit status API
+              try {
+                await github.rest.repos.createCommitStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  sha: context.sha,
+                  state: 'pending',
+                  description: 'CI is in-progress',
+                  context: 'ci-gate-status'
+                });
+                console.log("CI is in-progress - status set to pending");
+              } catch (error) {
+                console.log("Could not set commit status, but CI is in-progress");
+                console.log("Note: 'ci-gate' label indicates CI is running");
+              }
             } else if (hasFailed) {
               core.setFailed("'ci-failed' - Fix code and re-run CI");
             } else if (hasPassed) {


### PR DESCRIPTION
Replace core.setFailed() with GitHub Status API to show pending status when CI is in-progress, providing clearer state communication.