### PR TITLE
check-commits: add assisted-by to allowed trailers

### DIFF
--- a/check-commits
+++ b/check-commits
@@ -26,6 +26,7 @@ Signed-off-by
 Tested-by
 Reviewed-by
 Acked-by
+Assisted-by
 "
 
 n=0


### PR DESCRIPTION
Enable AI assistance acknowledgment in commit messages by adding "Assisted-by" to the sanctioned trailer list.

Assisted-by: cursor/claude-4-sonnet

(cherry picked from commit 859ec18b60c73b2c1fe471a02904ac11fb61e8e4)