### PR TITLE
nmstate: add interface-level ovs_extra support for OVS interfaces

### DIFF
--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -1745,6 +1745,15 @@ class NmstateNetConfig(os_net_config.NetConfig):
                         "%s=%s", "->".join(cfg["sub_tree"] + [key]), value
                     )
 
+    def get_handled_ovs_extra(self, original_list, unhandled_list):
+        """Get ovs_extra commands that were successfully handled.
+
+        :param original_list: Original list of ovs_extra commands
+        :param unhandled_list: List of commands that were not handled
+        :return: List of commands that were successfully handled
+        """
+        return [cmd for cmd in original_list if cmd not in unhandled_list]
+
     def parse_ovs_extra_for_bond_options(self, ovs_extras, name, data):
         """Parse ovs extra for bonding options
 
@@ -1999,7 +2008,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
             defroute=bridge.defroute, dhclient_args=bridge.dhclient_args,
             dns_servers=bridge.dns_servers,
             nm_controlled=None, onboot=bridge.onboot,
-            domain=bridge.domain, hwaddr=mac)
+            domain=bridge.domain, hwaddr=mac, ovs_extra=bridge.ovs_extra)
         self.add_ovs_interface(ovs_interface_port)
 
         ovs_int_port = {'name': ovs_interface_port.name}
@@ -2220,6 +2229,12 @@ class NmstateNetConfig(os_net_config.NetConfig):
 
         if ovs_interface.hwaddr:
             data[Interface.MAC] = ovs_interface.hwaddr
+
+        # Parse ovs_extra commands for the interface
+        if ovs_interface.ovs_extra:
+            self.parse_ovs_extra_for_iface(
+                ovs_interface.ovs_extra, ovs_interface.name, data)
+
         self.interface_data[ovs_interface.name + '-if'] = data
         self.__dump_config(data, msg=f"{ovs_interface.name}: Prepared config")
 

--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -649,7 +649,7 @@ class OvsInterface(_BaseOpts):
                  routes=None, rules=None, mtu=None, primary=False,
                  nic_mapping=None, persist_mapping=False, defroute=True,
                  dhclient_args=None, dns_servers=None, nm_controlled=False,
-                 onboot=True, domain=None, hwaddr=None):
+                 onboot=True, domain=None, hwaddr=None, ovs_extra=[]):
         addresses = addresses or []
         routes = routes or []
         rules = rules or []
@@ -661,6 +661,7 @@ class OvsInterface(_BaseOpts):
             dhclient_args, dns_servers,
             nm_controlled, onboot, domain)
         self.hwaddr = hwaddr
+        self.ovs_extra = format_ovs_extra(self, ovs_extra)
 
     @staticmethod
     def from_json(json):

--- a/os_net_config/tests/test_impl_nmstate.py
+++ b/os_net_config/tests/test_impl_nmstate.py
@@ -3069,6 +3069,26 @@ class TestNmstateNetConfig(base.TestCase):
                           self.provider.add_sriov_vf,
                           vf)
 
+    def test_enhanced_ovs_interface_constructor(self):
+        """Test enhanced OvsInterface constructor with ovs_extra parameter"""
+        nic_mapping = {'nic1': 'eth0', 'nic2': 'eth1'}
+        self.stubbed_mapped_nics = nic_mapping
+
+        # Test the new ovs_extra parameter in OvsInterface
+        ovs_extra_cmds = ["set interface {name} external_ids:vm-id=12345"]
+
+        ovs_interface = objects.OvsInterface(
+            'test-iface',
+            ovs_extra=ovs_extra_cmds
+        )
+
+        # Verify the ovs_extra is properly formatted and stored
+        expected = ["set interface test-iface external_ids:vm-id=12345"]
+        self.assertEqual(expected, ovs_interface.ovs_extra)
+
+        # Test adding it to provider
+        self.provider.add_ovs_interface(ovs_interface)
+
 
 class TestNmstateNetConfigApply(base.TestCase):
 


### PR DESCRIPTION
This patch introduces interface-level ovs_extra configuration support for OvsInterface objects.
This is patch 1 of a multi-patch series. Advanced bridge-level ovs_extra parsing and error handling will be implemented in subsequent patches.

Assisted-by: cursor/claude-4-sonnet