### PR TITLE
cli: add ExitCode enum to replace magic numbers in return values

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -63,7 +63,7 @@ the network configuration, but an alternate file can be used with the
 ``--config-file`` argument. The following arguments change the behaviour
 during configuration:
 
-- ``--detailed-exit-codes`` If enabled an exit code of ``2`` means that
+- ``--detailed-exit-codes`` If enabled an exit code of ``FILES_CHANGED`` (2) means that
   files were modified.
 - ``--exit-on-validation-errors`` Exit with an error if configuration
   file validation fails.

--- a/os_net_config/tests/test_cli.py
+++ b/os_net_config/tests/test_cli.py
@@ -23,6 +23,7 @@ import yaml
 
 import os_net_config
 from os_net_config import cli
+from os_net_config.cli import ExitCode
 from os_net_config import common
 from os_net_config.tests import base
 
@@ -74,7 +75,7 @@ class TestCli(base.TestCase):
         if os.path.isfile(common.SRIOV_CONFIG_FILE):
             os.remove(common.SRIOV_CONFIG_FILE)
 
-    def run_cli(self, argstr, exitcodes=(0,)):
+    def run_cli(self, argstr, exitcodes=(ExitCode.SUCCESS,)):
         for s in [sys.stdout, sys.stderr]:
             s.flush()
             s.truncate(0)
@@ -207,7 +208,8 @@ class TestCli(base.TestCase):
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
                                            '--exit-on-validation-errors '
                                            '-c %s --detailed-exit-codes'
-                                           % interface_yaml, exitcodes=(2,))
+                                           % interface_yaml,
+                                           exitcodes=(ExitCode.FILES_CHANGED,))
 
     def test_interface_noop_detailed_exit_codes_no_changes(self):
         interface_yaml = os.path.join(SAMPLE_BASE, 'interface.yaml')
@@ -225,7 +227,8 @@ class TestCli(base.TestCase):
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
                                            '--exit-on-validation-errors '
                                            '-c %s --detailed-exit-codes'
-                                           % interface_yaml, exitcodes=(0,))
+                                           % interface_yaml,
+                                           exitcodes=(ExitCode.SUCCESS,))
 
     def test_sriov_noop_output(self):
         def test_get_vf_devname(device, vfid):
@@ -504,7 +507,7 @@ class TestCli(base.TestCase):
             "", False, False, False
         )
 
-        self.assertEqual(2, ret_code)
+        self.assertEqual(ExitCode.FILES_CHANGED, ret_code)
 
     def test_config_provider_failure(self):
         """Test config_provider function with provider loading failure"""
@@ -523,7 +526,7 @@ class TestCli(base.TestCase):
             "", False, False, False
         )
 
-        self.assertEqual(1, ret_code)
+        self.assertEqual(ExitCode.ERROR, ret_code)
 
     def test_unconfig_provider_success(self):
         """Test unconfig_provider function with successful cleanup"""
@@ -548,7 +551,7 @@ class TestCli(base.TestCase):
         iface_array = [{"type": "interface", "name": "eth0"}]
         ret_code = cli.unconfig_provider("ifcfg", iface_array, "", False)
 
-        self.assertEqual(0, ret_code)
+        self.assertEqual(ExitCode.SUCCESS, ret_code)
 
     def test_unconfig_provider_failure(self):
         """Test unconfig_provider function with provider loading failure"""
@@ -564,7 +567,7 @@ class TestCli(base.TestCase):
         iface_array = [{"type": "interface", "name": "eth0"}]
         ret_code = cli.unconfig_provider("ifcfg", iface_array, "", False)
 
-        self.assertEqual(1, ret_code)
+        self.assertEqual(ExitCode.ERROR, ret_code)
 
     def test_get_iface_config_success(self):
         """Test successful config reading and validation"""


### PR DESCRIPTION
cli: add ExitCode enum to replace magic numbers in return values

- Define ExitCode enum with SUCCESS (0), ERROR (1), FILES_CHANGED (2)
- Replace all numeric return statements with descriptive enum values
- Update comments and docstrings to reference enum names
- Improve code readability and maintainability by eliminating magic numbers

This makes the exit code semantics self-documenting and easier to understand
for developers working with the CLI module.

Signed-off-by: Karthik Sundaravel <ksundara@redhat.com>