### PR TITLE
cli: add minimum configuration support with migration safety

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -42,6 +42,7 @@ class ExitCode(IntEnum):
     SUCCESS = 0          # Configuration successful
     ERROR = 1            # Configuration failed
     FILES_CHANGED = 2    # Configuration successful, files were modified
+    MINIMUM_CONFIG_FAILED = 5  # Minimum configuration failed
 
 
 logger = common.configure_logger()
@@ -291,12 +292,28 @@ def main(argv=sys.argv, main_logger=None):
     if not iface_array:
         return ExitCode.ERROR
 
+    try:
+        min_config = get_iface_config(
+            "minimum_config",
+            opts.config_file,
+            iface_mapping,
+            persist_mapping,
+            strict_validate=opts.exit_on_validation_errors,
+        )
+    except objects.InvalidConfigException as e:
+        logger.error("Schema validation failed for minimum_config\n%s", e)
+        return ExitCode.ERROR
+
     # Reset the DCB Config during rerun.
     # This is required to apply the new values and clear the old ones
     if utils.is_dcb_config_required():
         common.reset_dcb_map()
 
     if opts.purge_provider:
+        if not min_config:
+            logger.error("Minimum configuration is not provided and hence migration is not started")
+            return ExitCode.MINIMUM_CONFIG_FAILED
+
         purge_ret = unconfig_provider(
             opts.purge_provider,
             iface_array,
@@ -321,6 +338,43 @@ def main(argv=sys.argv, main_logger=None):
             main_logger.error("Unable to set provider for this operating "
                               "system.")
             return ExitCode.ERROR
+
+    # Apply minimum _config using the new provider.
+    try:
+        ret_code = minimum_config(
+            opts.provider,
+            min_config,
+            opts.no_activate,
+            opts.root_dir,
+            opts.noop)
+    except Exception as e:
+        logger.error(
+            "%s: ***Failed to configure minimum_config***\n%s",
+            opts.provider,
+            e
+        )
+        return ExitCode.ERROR
+
+    if opts.purge_provider:
+        # For migration from old provider to new provider, the minimum_config
+        # needs to be defined. Any failure to configure minimum_config will be
+        # considered as a failure to migrate.
+        if ret_code != ExitCode.SUCCESS:
+            logger.error(
+                "%s: Failed to configure minimum_config. "
+                "First phase of migration failed",
+                opts.provider,
+            )
+            return ret_code
+        else:
+            logger.info(
+                "First phase of migration from %s -> %s is successful. "
+                "Run os-net-config --provider %s  to complete the migration",
+                opts.purge_provider,
+                opts.provider,
+                opts.provider
+            )
+            return ExitCode.SUCCESS
 
     try:
         logger.info("%s: Applying network_config section", opts.provider)
@@ -572,6 +626,34 @@ def get_iface_config(
             for e in validation_errors:
                 logger.warning(e)
     return iface_array
+
+
+def minimum_config(provider,
+                   min_config,
+                   no_activate,
+                   root_dir,
+                   noop):
+    if not min_config:
+        logger.warning("minimum_config is not provided")
+        return ExitCode.MINIMUM_CONFIG_FAILED
+
+    logger.info("%s: Running minimum config", provider)
+    ret = config_provider(
+        provider,
+        "minimum_config",
+        min_config,
+        root_dir,
+        noop,
+        no_activate,
+        False,
+    )
+    if ret == ExitCode.SUCCESS or ret == ExitCode.FILES_CHANGED:
+        logger.info("%s: minimum_config is completed", provider)
+        ret = ExitCode.SUCCESS
+    else:
+        logger.error("%s: failed to configure minimum_config", provider)
+        ret = ExitCode.MINIMUM_CONFIG_FAILED
+    return ret
 
 
 if __name__ == '__main__':

--- a/os_net_config/tests/test_cli.py
+++ b/os_net_config/tests/test_cli.py
@@ -99,6 +99,11 @@ class TestCli(base.TestCase):
         return address_map.get(ifname, None)
 
     def test_bond_noop_output(self):
+        timestamp_rex = re.compile(
+            (r'bond\.(yaml|json)|^[\d]{4}-[\d]{2}-[\d]{2} '
+             r'[\d]{2}:[\d]{2}:[\d]{2}\.[\d]{3} '),
+            flags=re.M
+        )
         bond_yaml = os.path.join(SAMPLE_BASE, 'bond.yaml')
         bond_json = os.path.join(SAMPLE_BASE, 'bond.json')
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
@@ -116,9 +121,16 @@ class TestCli(base.TestCase):
                           'DEVICETYPE=ovs']
         for dev in sanity_devices:
             self.assertIn(dev, stdout_yaml)
+        stdout_yaml = timestamp_rex.sub('', stdout_yaml)
+        stdout_json = timestamp_rex.sub('', stdout_json)
         self.assertEqual(stdout_yaml, stdout_json)
 
     def test_ivs_noop_output(self):
+        timestamp_rex = re.compile(
+            (r'ivs\.(yaml|json)|^[\d]{4}-[\d]{2}-[\d]{2} '
+             r'[\d]{2}:[\d]{2}:[\d]{2}\.[\d]{3} '),
+            flags=re.M
+        )
         ivs_yaml = os.path.join(SAMPLE_BASE, 'ivs.yaml')
         ivs_json = os.path.join(SAMPLE_BASE, 'ivs.json')
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
@@ -136,9 +148,16 @@ class TestCli(base.TestCase):
                           'DEVICETYPE=ivs']
         for dev in sanity_devices:
             self.assertIn(dev, stdout_yaml)
+        stdout_yaml = timestamp_rex.sub('', stdout_yaml)
+        stdout_json = timestamp_rex.sub('', stdout_json)
         self.assertEqual(stdout_yaml, stdout_json)
 
     def test_bridge_noop_output(self):
+        timestamp_rex = re.compile(
+            (r'bridge_dhcp\.(yaml|json)|^[\d]{4}-[\d]{2}-[\d]{2} '
+             r'[\d]{2}:[\d]{2}:[\d]{2}\.[\d]{3} '),
+            flags=re.M
+        )
         bridge_yaml = os.path.join(SAMPLE_BASE, 'bridge_dhcp.yaml')
         bridge_json = os.path.join(SAMPLE_BASE, 'bridge_dhcp.json')
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=eni --noop '
@@ -154,9 +173,16 @@ class TestCli(base.TestCase):
                           'ovs_type OVSBridge']
         for dev in sanity_devices:
             self.assertIn(dev, stdout_yaml)
+        stdout_yaml = timestamp_rex.sub('', stdout_yaml)
+        stdout_json = timestamp_rex.sub('', stdout_json)
         self.assertEqual(stdout_yaml, stdout_json)
 
     def test_vlan_noop_output(self):
+        timestamp_rex = re.compile(
+            (r'bridge_vlan\.(yaml|json)|^[\d]{4}-[\d]{2}-[\d]{2} '
+             r'[\d]{2}:[\d]{2}:[\d]{2}\.[\d]{3} '),
+            flags=re.M
+        )
         vlan_yaml = os.path.join(SAMPLE_BASE, 'bridge_vlan.yaml')
         vlan_json = os.path.join(SAMPLE_BASE, 'bridge_vlan.json')
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
@@ -173,9 +199,16 @@ class TestCli(base.TestCase):
                           'DEVICETYPE=ovs']
         for dev in sanity_devices:
             self.assertIn(dev, stdout_yaml)
+        stdout_yaml = timestamp_rex.sub('', stdout_yaml)
+        stdout_json = timestamp_rex.sub('', stdout_json)
         self.assertEqual(stdout_yaml, stdout_json)
 
     def test_interface_noop_output(self):
+        timestamp_rex = re.compile(
+            (r'interface\.(yaml|json)|^[\d]{4}-[\d]{2}-[\d]{2} '
+             r'[\d]{2}:[\d]{2}:[\d]{2}\.[\d]{3} '),
+            flags=re.M
+        )
         interface_yaml = os.path.join(SAMPLE_BASE, 'interface.yaml')
         interface_json = os.path.join(SAMPLE_BASE, 'interface.json')
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
@@ -191,6 +224,8 @@ class TestCli(base.TestCase):
                           'IPADDR=192.0.2.1']
         for dev in sanity_devices:
             self.assertIn(dev, stdout_yaml)
+        stdout_yaml = timestamp_rex.sub('', stdout_yaml)
+        stdout_json = timestamp_rex.sub('', stdout_json)
         self.assertEqual(stdout_yaml, stdout_json)
 
     def test_bridge_noop_rootfs(self):
@@ -246,6 +281,11 @@ class TestCli(base.TestCase):
         def test_get_pci_device_driver(pci_address):
             return 'iavf'
 
+        timestamp_rex = re.compile(
+            (r'sriov_pf\.(yaml|json)|^[\d]{4}-[\d]{2}-[\d]{2} '
+             r'[\d]{2}:[\d]{2}:[\d]{2}\.[\d]{3} '),
+            flags=re.M
+        )
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
         self.stub_out('os_net_config.common.get_pci_address',
@@ -274,6 +314,8 @@ class TestCli(base.TestCase):
                           'TYPE=OVSBridge']
         for dev in sanity_devices:
             self.assertIn(dev, stdout_yaml)
+        stdout_yaml = timestamp_rex.sub('', stdout_yaml)
+        stdout_json = timestamp_rex.sub('', stdout_json)
         self.assertEqual(stdout_yaml, stdout_json)
 
     def test_sriov_vf_with_dpdk_noop_output(self):
@@ -289,6 +331,11 @@ class TestCli(base.TestCase):
         def test_get_pci_device_driver(pci_address):
             return 'iavf'
 
+        timestamp_rex = re.compile(
+            (r'sriov_pf_ovs_dpdk\.(yaml|json)|^[\d]{4}-[\d]{2}-[\d]{2} '
+             r'[\d]{2}:[\d]{2}:[\d]{2}\.[\d]{3} '),
+            flags=re.M
+        )
         self.stub_out('os_net_config.utils.get_vf_devname',
                       test_get_vf_devname)
         self.stub_out('os_net_config.common.get_pci_address',
@@ -315,9 +362,16 @@ class TestCli(base.TestCase):
                           'TYPE=OVSDPDKPort']
         for dev in sanity_devices:
             self.assertIn(dev, stdout_yaml)
+        stdout_yaml = timestamp_rex.sub('', stdout_yaml)
+        stdout_json = timestamp_rex.sub('', stdout_json)
         self.assertEqual(stdout_yaml, stdout_json)
 
     def test_ovs_dpdk_bond_noop_output(self):
+        timestamp_rex = re.compile(
+            (r'ovs_dpdk_bond\.(yaml|json)|^[\d]{4}-[\d]{2}-[\d]{2} '
+             r'[\d]{2}:[\d]{2}:[\d]{2}\.[\d]{3} '),
+            flags=re.M
+        )
         ivs_yaml = os.path.join(SAMPLE_BASE, 'ovs_dpdk_bond.yaml')
         ivs_json = os.path.join(SAMPLE_BASE, 'ovs_dpdk_bond.json')
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
@@ -334,9 +388,16 @@ class TestCli(base.TestCase):
                           'TYPE=OVSDPDKBond']
         for dev in sanity_devices:
             self.assertIn(dev, stdout_yaml)
+        stdout_yaml = timestamp_rex.sub('', stdout_yaml)
+        stdout_json = timestamp_rex.sub('', stdout_json)
         self.assertEqual(stdout_yaml, stdout_json)
 
     def test_nfvswitch_noop_output(self):
+        timestamp_rex = re.compile(
+            (r'nfvswitch\.(yaml|json)|^[\d]{4}-[\d]{2}-[\d]{2} '
+             r'[\d]{2}:[\d]{2}:[\d]{2}\.[\d]{3} '),
+            flags=re.M
+        )
         nfvswitch_yaml = os.path.join(SAMPLE_BASE, 'nfvswitch.yaml')
         nfvswitch_json = os.path.join(SAMPLE_BASE, 'nfvswitch.json')
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
@@ -354,9 +415,16 @@ class TestCli(base.TestCase):
                           'DEVICETYPE=nfvswitch']
         for dev in sanity_devices:
             self.assertIn(dev, stdout_yaml)
+        stdout_yaml = timestamp_rex.sub('', stdout_yaml)
+        stdout_json = timestamp_rex.sub('', stdout_json)
         self.assertEqual(stdout_yaml, stdout_json)
 
     def test_ovs_dpdk_noop_output(self):
+        timestamp_rex = re.compile(
+            (r'ovs_dpdk\.(yaml|json)|^[\d]{4}-[\d]{2}-[\d]{2} '
+             r'[\d]{2}:[\d]{2}:[\d]{2}\.[\d]{3} '),
+            flags=re.M
+        )
         ivs_yaml = os.path.join(SAMPLE_BASE, 'ovs_dpdk.yaml')
         ivs_json = os.path.join(SAMPLE_BASE, 'ovs_dpdk.json')
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
@@ -373,6 +441,8 @@ class TestCli(base.TestCase):
                           'TYPE=OVSDPDKPort']
         for dev in sanity_devices:
             self.assertIn(dev, stdout_yaml)
+        stdout_yaml = timestamp_rex.sub('', stdout_yaml)
+        stdout_json = timestamp_rex.sub('', stdout_json)
         self.assertEqual(stdout_yaml, stdout_json)
 
     def test_nic_mapping_report_output(self):
@@ -412,6 +482,11 @@ class TestCli(base.TestCase):
         self.assertNotIn('em4', stdout_list.values())
 
     def test_contrail_vrouter_noop_output(self):
+        timestamp_rex = re.compile(
+            (r'contrail_vrouter\.(yaml|json)|^[\d]{4}-[\d]{2}-[\d]{2} '
+             r'[\d]{2}:[\d]{2}:[\d]{2}\.[\d]{3} '),
+            flags=re.M
+        )
         cvi_yaml = os.path.join(SAMPLE_BASE, 'contrail_vrouter.yaml')
         cvi_json = os.path.join(SAMPLE_BASE, 'contrail_vrouter.json')
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
@@ -428,9 +503,16 @@ class TestCli(base.TestCase):
                           'TYPE=kernel_mode']
         for dev in sanity_devices:
             self.assertIn(dev, stdout_yaml)
+        stdout_yaml = timestamp_rex.sub('', stdout_yaml)
+        stdout_json = timestamp_rex.sub('', stdout_json)
         self.assertEqual(stdout_yaml, stdout_json)
 
     def test_contrail_vrouter_vlan_noop_output(self):
+        timestamp_rex = re.compile(
+            (r'contrail_vrouter_vlan\.(yaml|json)|^[\d]{4}-[\d]{2}-[\d]{2} '
+             r'[\d]{2}:[\d]{2}:[\d]{2}\.[\d]{3} '),
+            flags=re.M
+        )
         cvi_yaml = os.path.join(SAMPLE_BASE, 'contrail_vrouter_vlan.yaml')
         cvi_json = os.path.join(SAMPLE_BASE, 'contrail_vrouter_vlan.json')
         stdout_yaml, stderr = self.run_cli('ARG0 --provider=ifcfg --noop '
@@ -447,6 +529,8 @@ class TestCli(base.TestCase):
                           'TYPE=kernel_mode']
         for dev in sanity_devices:
             self.assertIn(dev, stdout_yaml)
+        stdout_yaml = timestamp_rex.sub('', stdout_yaml)
+        stdout_json = timestamp_rex.sub('', stdout_json)
         self.assertEqual(stdout_yaml, stdout_json)
 
     def test_contrail_vrouter_dpdk_noop_output(self):


### PR DESCRIPTION
Add support for applying minimum network configuration before the main
network_config section. The minimum_config uses the same YAML template
format as network_config and provides a safety mechanism for network
migrations and bare minimum connectivity scenarios.

Key features:
- Parse and validate minimum_config section from config.yaml
- Apply minimum_config before network_config to ensure connectivity
- Require minimum_config for provider migration (--purge-provider)
- Add ExitCode.MINIMUM_CONFIG_FAILED (5) for specific error reporting
- Proper error handling with schema validation

Migration workflow:
1. Validate minimum_config is present for migration
2. Apply minimum_config (Phase 1 of migration)
3. On success, user runs second command to complete migration

This ensures network connectivity is maintained during provider
transitions and provides a fallback mechanism for critical scenarios.

Signed-off-by: Karthik Sundaravel <ksundara@redhat.com>