### PR TITLE
utils: add gettimeofday() for timestamping backup

### DIFF
--- a/os_net_config/common.py
+++ b/os_net_config/common.py
@@ -144,6 +144,11 @@ def print_config(config, msg=""):
     logger.info("\n%s:\n%s", msg, cfg_dump)
 
 
+def get_timestamp():
+    """Return the current timestamp as a string in YYYYMMDD_HHMMSS format."""
+    return time.strftime("%Y%m%d_%H%M%S", time.localtime())
+
+
 def get_dev_path(ifname, path=None):
     if not path:
         path = ""


### PR DESCRIPTION
Added the gettimeofday() method, which could be used in timestamping the creation of backup files/folders.