### PR TITLE
cli: move exit codes to dedicated module with bitmask design

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -16,7 +16,6 @@
 
 
 import argparse
-from enum import IntEnum
 import importlib
 import json
 import os
@@ -24,24 +23,13 @@ import sys
 import yaml
 
 from os_net_config import common
+from os_net_config.exit_codes import ExitCode
+from os_net_config.exit_codes import get_exit_code
+from os_net_config.exit_codes import has_failures
 from os_net_config import objects
 from os_net_config import utils
 from os_net_config import validator
 from os_net_config import version
-
-
-class ExitCode(IntEnum):
-    """Exit codes used by os-net-config.
-
-    These codes indicate the result of configuration operations:
-    - SUCCESS: Configuration completed successfully
-    - ERROR: Configuration failed due to an error
-    Below values are returned when --detailed_exit_code is enabled in cli
-    - FILES_CHANGED: Configuration successful and files were modified
-    """
-    SUCCESS = 0          # Configuration successful
-    ERROR = 1            # Configuration failed
-    FILES_CHANGED = 2    # Configuration successful, files were modified
 
 
 logger = common.configure_logger()
@@ -53,6 +41,8 @@ _PROVIDERS = {
     'iproute': 'IprouteNetConfig',
     'nmstate': 'NmstateNetConfig',
 }
+
+__all__ = ['ExitCode', 'get_exit_code', 'has_failures']
 
 
 def parse_opts(argv):
@@ -212,6 +202,8 @@ def is_nmstate_available():
 
 
 def main(argv=sys.argv, main_logger=None):
+    onc_ret_code = ExitCode.SUCCESS
+
     opts = parse_opts(argv)
 
     common.set_noop(opts.noop)
@@ -243,7 +235,6 @@ def main(argv=sys.argv, main_logger=None):
     if opts.interfaces is not None:
         reported_nics = {}
         mapped_nics = objects.mapped_nics(iface_mapping)
-        retval = ExitCode.SUCCESS
         if len(opts.interfaces) > 0:
             for requested_nic in opts.interfaces:
                 found = False
@@ -262,7 +253,7 @@ def main(argv=sys.argv, main_logger=None):
                         reported_nics[requested_nic] = requested_nic
                         found = True
                 if not found:
-                    retval = ExitCode.ERROR
+                    onc_ret_code |= ExitCode.ERROR
             if reported_nics:
                 main_logger.debug(
                     "Interface mapping requested for interface: %s",
@@ -275,7 +266,7 @@ def main(argv=sys.argv, main_logger=None):
         # cleanly, otherwise exit with status ERROR.
         main_logger.debug("Interface report requested, exiting after report.")
         print(json.dumps(reported_nics))
-        return retval
+        return onc_ret_code
     try:
         iface_array = get_iface_config(
             "network_config",
@@ -285,11 +276,15 @@ def main(argv=sys.argv, main_logger=None):
             strict_validate=opts.exit_on_validation_errors,
         )
     except objects.InvalidConfigException as e:
-        main_logger.error("Schema validation failed for network_config\n%s", e)
-        return ExitCode.ERROR
+        main_logger.error(
+            "Schema validation failed for network_config with error: \n%s", e
+        )
+        return get_exit_code(opts.detailed_exit_codes,
+                             onc_ret_code | ExitCode.SCHEMA_VALIDATION_FAILED)
 
     if not iface_array:
-        return ExitCode.ERROR
+        return get_exit_code(opts.detailed_exit_codes,
+                             onc_ret_code | ExitCode.ERROR)
 
     # Reset the DCB Config during rerun.
     # This is required to apply the new values and clear the old ones
@@ -303,11 +298,16 @@ def main(argv=sys.argv, main_logger=None):
             opts.root_dir,
             opts.noop
         )
-        if purge_ret != ExitCode.SUCCESS:
+        onc_ret_code |= purge_ret
+        if purge_ret == ExitCode.PURGE_FAILED:
             main_logger.error(
-                "Failed to purge %s provider", opts.purge_provider
+                "%s: Failed to purge provider", opts.purge_provider
             )
-            return purge_ret
+            return get_exit_code(opts.detailed_exit_codes, onc_ret_code)
+        else:
+            main_logger.info(
+                "%s: Purged provider successfully", opts.purge_provider
+            )
 
     if not opts.provider:
         ifcfg_path = f'{opts.root_dir}/etc/sysconfig/network-scripts/'
@@ -320,43 +320,48 @@ def main(argv=sys.argv, main_logger=None):
         else:
             main_logger.error("Unable to set provider for this operating "
                               "system.")
-            return ExitCode.ERROR
-
-    try:
-        logger.info("%s: Applying network_config section", opts.provider)
-        ret_code = config_provider(
-            opts.provider,
-            "network_config",
-            iface_array,
-            opts.root_dir,
-            opts.noop,
-            opts.no_activate,
-            opts.cleanup,
-        )
-    except Exception as e:
+            return get_exit_code(opts.detailed_exit_codes,
+                                 onc_ret_code | ExitCode.ERROR)
+    logger.info("%s: Applying network_config section", opts.provider)
+    ret_code = config_provider(
+        opts.provider,
+        "network_config",
+        iface_array,
+        opts.root_dir,
+        opts.noop,
+        opts.no_activate,
+        opts.cleanup,
+    )
+    if ret_code == ExitCode.ERROR:
         logger.error(
-            "%s: *** Failed to apply network_config section ***\n%s",
+            "%s: Failed to configure network_config. ",
             opts.provider,
-            e
         )
-        ret_code = ExitCode.ERROR
-
-    if utils.is_dcb_config_required():
-        # Apply the DCB Config
-        try:
-            from os_net_config import dcb_config
-        except ImportError as e:
-            logger.error("cannot apply DCB configuration: %s", e)
-            return ExitCode.ERROR
-
-        utils.configure_dcb_config_service()
-        dcb_apply = dcb_config.DcbApplyConfig()
-        dcb_apply.apply()
-
-    if opts.detailed_exit_codes or ret_code == ExitCode.ERROR:
-        return ret_code
+        return get_exit_code(opts.detailed_exit_codes,
+                             onc_ret_code | ExitCode.NETWORK_CONFIG_FAILED)
     else:
-        return ExitCode.SUCCESS
+        onc_ret_code |= ret_code
+        main_logger.info(
+            "%s: Configured network_config successfully", opts.provider
+        )
+
+    # If the configuration is successful, apply the DCB config
+    if has_failures(onc_ret_code) is False:
+        if utils.is_dcb_config_required():
+            common.reset_dcb_map()
+
+            # Apply the DCB Config
+            try:
+                from os_net_config import dcb_config
+            except ImportError as e:
+                logger.error("cannot apply DCB configuration: %s", e)
+                return (onc_ret_code | ExitCode.DCB_CONFIG_FAILED)
+
+            utils.configure_dcb_config_service()
+            dcb_apply = dcb_config.DcbApplyConfig()
+            dcb_apply.apply()
+
+    return get_exit_code(opts.detailed_exit_codes, onc_ret_code)
 
 
 def unconfig_provider(provider_name,
@@ -380,7 +385,7 @@ def unconfig_provider(provider_name,
         logger.error(
             "%s: cannot load purge provider, error %s", provider_name, e
         )
-        return ExitCode.ERROR
+        return ExitCode.PURGE_FAILED
 
     for iface_json in iface_array:
         try:

--- a/os_net_config/exit_codes.py
+++ b/os_net_config/exit_codes.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2025-2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from enum import IntEnum
+
+
+class ExitCode(IntEnum):
+    """Exit codes used by os-net-config.
+
+    Uses bitmask design where each bit indicates failure (1) or success (0).
+    This allows combining multiple section results efficiently.
+
+    Bit positions:
+    - Bit 0: General error
+    - Bit 1: Files changed (success indicator)
+    - Bit 2: Network config failed
+    - Bit 3: Fallback failed
+    - Bit 4: Minimum config failed
+    - Bit 5: Remove config failed
+    - Bit 6: Purge failed
+    - Bit 7: DCB config failed
+    """
+
+    SUCCESS = 0x0                    # 0b0000000 - All operations successful
+    ERROR = 0x1                      # 0b0000001 - General error
+    FILES_CHANGED = 0x2              # 0b0000010 - Files modified (success)
+
+    # Failure bits for each section (bit set = failed)
+    NETWORK_CONFIG_FAILED = 0x4       # 0b0000100 - Network config failed
+    FALLBACK_FAILED = 0x8             # 0b0001000 - Fallback failed
+    MINIMUM_CONFIG_FAILED = 0x10      # 0b0010000 - Minimum config failed
+    REMOVE_CONFIG_FAILED = 0x20       # 0b0100000 - Remove config failed
+    PURGE_FAILED = 0x40               # 0b1000000 - Purge failed
+    DCB_CONFIG_FAILED = 0x80          # 0b10000000 - DCB config failed
+    SCHEMA_VALIDATION_FAILED = 0x100  # 0b100000000 - Schema validation failed
+
+
+def get_exit_code(detailed_exit_codes, ret_code):
+    """Map return codes based on detailed mode.
+
+    If detailed is True, return the given code. Otherwise, simplify to
+    SUCCESS/ERROR based on failure bits.
+
+    In the optimized bitmask design:
+    - Any failure bit set (bits 0,2-6) = ERROR
+    - Only SUCCESS (0) or FILES_CHANGED (bit 1) = SUCCESS
+    """
+    if detailed_exit_codes:
+        return ret_code
+
+    # Check for any failure bits (all bits except FILES_CHANGED)
+    failure_mask = ~ExitCode.FILES_CHANGED  # All bits except bit 1
+
+    if ret_code & failure_mask:
+        return ExitCode.ERROR
+
+    # Only SUCCESS or FILES_CHANGED remain
+    return ExitCode.SUCCESS
+
+
+def has_failures(ret_code):
+    """Check if any failure bits are set in the return code.
+
+    Returns:
+        bool: True if any operation failed, False otherwise
+    """
+    failure_mask = ~ExitCode.FILES_CHANGED  # All bits except FILES_CHANGED
+    return bool(ret_code & failure_mask)

--- a/os_net_config/tests/test_cli.py
+++ b/os_net_config/tests/test_cli.py
@@ -652,7 +652,7 @@ class TestCli(base.TestCase):
         iface_array = [{"type": "interface", "name": "eth0"}]
         ret_code = cli.unconfig_provider("ifcfg", iface_array, "", False)
 
-        self.assertEqual(ExitCode.ERROR, ret_code)
+        self.assertEqual(ExitCode.PURGE_FAILED, ret_code)
 
     def test_get_iface_config_success(self):
         """Test successful config reading and validation"""


### PR DESCRIPTION
- Move ExitCode and get_exit_code to os_net_config/exit_codes.py
- Re-export ExitCode/get_exit_code from cli for backward compatibility
- Preserve detailed-exit-codes mapping behavior
- Apply DCB config only on successful apply (SUCCESS or FILES_CHANGED)

Notes:
- This refactor prepares for upcoming PRs: minimum_config, fallback_config, and remove_config.