### PR TITLE
nmstate: add helpers to get pci address of DPDK ports / bonds

### DIFF
--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -2818,3 +2818,18 @@ class NmstateNetConfig(os_net_config.NetConfig):
             "Succesfully applied the network config with nmstate provider"
         )
         return updated_interfaces
+
+    def _get_dpdk_port_pci_address(self, dpdk_port_name):
+        """Return the dpdk-devargs (PCI address) for a DPDK port interface.
+
+        :param dpdk_port_name: Name of the DPDK port interface
+        :return: List containing PCI address, or empty list if not found
+        """
+        state = self.iface_state(name=dpdk_port_name)
+        if state:
+            dpdk_config = state.get("dpdk", {})
+            if dpdk_config:
+                devargs = dpdk_config.get("devargs")
+                if devargs:
+                    return [devargs]
+        return []


### PR DESCRIPTION
The `remove_config` feature needs the helper methods to fetch the pci address of the DPDK ports and the DPDK bonds. The pci address fetched could be later used in detaching it from the dpdk ports and unbind the same from vfio-pci driver. Since the `remove_config` feature could remove a dpdk interface which is not previously configured by os-net-config, the usage of dpdk map is avoided. The current interface states listed by `netinfo` is instead used in reading the PCI addresses.