### PR TITLE
[WIP] ifcfg: add device removal support for network interfaces

### DIFF
--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -46,7 +46,7 @@ _ROUTE_TABLE_DEFAULT = """# reserved values
 #
 #1\tinr.ruhep\n"""
 
-PURGE_IFCFG_FILES = '/var/lib/os-net-config/ifcfg-purge/'
+BACKUP_IFCFG_FILES_PATH = '/var/lib/os-net-config/ifcfg-purge/'
 NETWORK_SCRIPTS_PATH = '/etc/sysconfig/network-scripts/'
 
 
@@ -2366,25 +2366,25 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         route6_file = route6_config_path(iface_name)
         rule_file = route_rule_config_path(iface_name)
 
-        if not os.path.exists(PURGE_IFCFG_FILES):
-            os.makedirs(PURGE_IFCFG_FILES)
+        if not os.path.exists(BACKUP_IFCFG_FILES_PATH):
+            os.makedirs(BACKUP_IFCFG_FILES_PATH)
         if os.path.exists(ifcfg_file):
-            new_ifcfg_file = os.path.join(PURGE_IFCFG_FILES,
+            new_ifcfg_file = os.path.join(BACKUP_IFCFG_FILES_PATH,
                                           f'ifcfg-{iface_name}')
             logger.info("Moving %s -> %s", ifcfg_file, new_ifcfg_file)
             shutil.move(ifcfg_file, new_ifcfg_file)
         if os.path.exists(route_file):
-            new_route_file = os.path.join(PURGE_IFCFG_FILES,
+            new_route_file = os.path.join(BACKUP_IFCFG_FILES_PATH,
                                           f'route-{iface_name}')
             logger.info("Moving %s -> %s", route_file, new_route_file)
             shutil.move(route_file, new_route_file)
         if os.path.exists(route6_file):
-            new_route6_file = os.path.join(PURGE_IFCFG_FILES,
+            new_route6_file = os.path.join(BACKUP_IFCFG_FILES_PATH,
                                            f'route6-{iface_name}')
             logger.info("Moving %s - %s", route6_file, new_route6_file)
             shutil.move(route6_file, new_route6_file)
         if os.path.exists(rule_file):
-            new_rule_file = os.path.join(PURGE_IFCFG_FILES,
+            new_rule_file = os.path.join(BACKUP_IFCFG_FILES_PATH,
                                          f'rule-{iface_name}')
             logger.info("Moving %s -> %s", rule_file, new_rule_file)
             shutil.move(rule_file, new_rule_file)
@@ -2401,12 +2401,12 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
     def _restore_ifcfg_files(self):
         logger.info('Restoring the ifcfg files')
-        for file in os.listdir(PURGE_IFCFG_FILES):
+        for file in os.listdir(BACKUP_IFCFG_FILES_PATH):
             if file.startswith('ifcfg-') or \
                 file.startswith('rule-') or \
                 file.startswith('route-') or \
                 file.startswith('route6-'):
-                file_path = os.path.join(PURGE_IFCFG_FILES, file)
+                file_path = os.path.join(BACKUP_IFCFG_FILES_PATH, file)
                 new_file_path = os.path.join(NETWORK_SCRIPTS_PATH, file)
                 try:
                     shutil.copy(file_path, new_file_path)
@@ -2445,3 +2445,91 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                 logger.info(
                     "%s: Device is not managed by ifcfg provider", iface_name
                 )
+
+    def remove_devices(self, remove_device_list):
+        """Remove a list of devices using ordered processing.
+
+        This method processes RemoveNetDevice objects in the specified order:
+        ovs_dpdk_port -> ovs_dpdk_bond -> linux_bond -> interface ->
+        ovs_bridge -> ovs_user_bridge -> sriov_pf
+
+        :param remove_device_list: List of RemoveNetDevice objects
+        :type remove_device_list: list[RemoveNetDevice]
+        """
+        if not remove_device_list:
+            logger.debug("remove_devices: No devices to remove")
+            return
+
+        logger.info('removing network devices...')
+
+        # Check if we need to backup files for certain device types
+        backup_required_types = ['ovs_dpdk_port', 'ovs_dpdk_bond',
+                                 'sriov_vf', 'sriov_pf']
+        needs_backup = any(device.dev_type in backup_required_types
+                           for device in remove_device_list)
+        if needs_backup:
+            logger.info("Backing up configuration files before device removal")
+            if not self.noop:
+                # Create a backup folder with the current timestamp
+                backup_path = os.path.join(BACKUP_IFCFG_FILES_PATH,
+                                           common.get_timestamp())
+                os.makedirs(backup_path, exist_ok=True)
+                utils.backup_map_files(backup_path)
+
+        # Process devices in specific order
+        processing_order = ['ovs_dpdk_port', 'ovs_dpdk_bond', 'linux_bond',
+                            'interface', 'vlan', 'sriov_vf', 'ovs_bridge',
+                            'ovs_user_bridge', 'sriov_pf']
+
+        for device_type in processing_order:
+            devices_of_type = [device for device in remove_device_list
+                               if device.dev_type == device_type]
+
+            if devices_of_type:
+                for device in devices_of_type:
+                    self._process_device_removal(device)
+
+    def _process_device_removal(self, device):
+        """Process the removal of a single device.
+
+        :param device: RemoveNetDevice object to remove
+        """
+        logger.info("%s: removing %s", device.dev_name, device.dev_type)
+
+        if self.noop:
+            return
+
+        try:
+
+            # Device-specific cleanup
+            if device.dev_type in ['ovs_dpdk_port', 'ovs_dpdk_bond']:
+                # For DPDK: Bring down interface, get PCI addresses, clean up
+                self.ifdown(device.dev_name)
+                # Get PCI addresses based on device type
+                if device.dev_type == 'ovs_dpdk_port':
+                    pci_address = self.get_dpdk_port_pci_addresses(
+                        device.dev_name)
+                    pci_addresses = [pci_address] if pci_address else []
+                else:  # ovs_dpdk_bond
+                    pci_addresses = self.get_dpdk_bond_pci_addresses(
+                        device.dev_name)
+                # Remove all DPDK interfaces
+                for pci_address in pci_addresses:
+                    utils.remove_dpdk_interface(pci_address)
+            elif device.dev_type == 'sriov_pf':
+                # For SR-IOV: Reset, bring down interface, clean up entries
+                sriov_config.reset_sriov_pf(device.dev_name)
+                self.ifdown(device.dev_name)
+                utils.remove_sriov_entries_for_pf(device.dev_name)
+            else:
+                # For all other device types: just bring down interface
+                self.ifdown(device.dev_name)
+
+            # Remove ifcfg configuration file
+            remove_ifcfg_config(device.dev_name)
+
+        except Exception as e:
+            msg = (f"{device.dev_name}: failed to remove {device.dev_type} "
+                   f"device: {e}")
+            logger.error(msg)
+            raise os_net_config.ConfigurationError(msg)

--- a/os_net_config/tests/test_impl_ifcfg.py
+++ b/os_net_config/tests/test_impl_ifcfg.py
@@ -3033,3 +3033,307 @@ class TestIfcfgNetConfigApply(base.TestCase):
                           self.provider.apply)
         # Even though the first one failed, we should have attempted both
         self.assertEqual(2, len(self.provider.errors))
+
+
+class TestIfcfgNetConfigDeviceRemoval(base.TestCase):
+
+    def setUp(self):
+        super(TestIfcfgNetConfigDeviceRemoval, self).setUp()
+        self.temp_dir = tempfile.mkdtemp()
+        self.ifcfg_path = os.path.join(self.temp_dir, 'ifcfg-eth0')
+
+        # Create a temporary ifcfg file for testing
+        with open(self.ifcfg_path, 'w') as f:
+            f.write(_BASE_IFCFG)
+
+        self.provider = impl_ifcfg.IfcfgNetConfig(noop=True,
+                                                  root_dir=self.temp_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+        super(TestIfcfgNetConfigDeviceRemoval, self).tearDown()
+
+    def test_remove_devices_empty_list(self):
+        # Test with empty device list
+        self.provider.remove_devices([])
+        # Should not raise any exceptions
+
+    def test_remove_devices_noop_mode(self):
+        # Test noop mode
+        device = objects.RemoveNetDevice('eth0', 'interface')
+        self.provider.remove_devices([device])
+        # In noop mode, should not actually remove anything
+
+    def test_remove_devices_ordered_processing(self):
+        # Test multiple devices are processed in correct order
+        devices = [
+            objects.RemoveNetDevice('sriov-pf', 'sriov_pf'),
+            objects.RemoveNetDevice('bond0', 'linux_bond'),
+            objects.RemoveNetDevice('dpdk0', 'ovs_dpdk_port'),
+            objects.RemoveNetDevice('dpdkbond0', 'ovs_dpdk_bond'),
+            objects.RemoveNetDevice('eth0', 'interface'),
+            objects.RemoveNetDevice('br0', 'ovs_bridge'),
+            objects.RemoveNetDevice('br-user', 'ovs_user_bridge'),
+            objects.RemoveNetDevice('vf0', 'sriov_vf')
+        ]
+
+        # Mock the processing method to track call order
+        processed_devices = []
+
+        def mock_process_device_removal(self, device):
+            processed_devices.append((device.dev_name, device.dev_type))
+
+        self.stub_out(
+            'os_net_config.impl_ifcfg.IfcfgNetConfig._process_device_removal',
+            mock_process_device_removal)
+
+        self.provider.remove_devices(devices)
+        # Verify devices were processed in correct order
+        expected_order = [
+            ('dpdk0', 'ovs_dpdk_port'),      # DPDK ports first
+            ('dpdkbond0', 'ovs_dpdk_bond'),  # DPDK bonds second
+            ('bond0', 'linux_bond'),         # Then linux bonds
+            ('eth0', 'interface'),           # Then interfaces
+            ('vf0', 'sriov_vf'),             # Then SR-IOV VFs
+            ('br0', 'ovs_bridge'),           # Then OVS bridges
+            ('br-user', 'ovs_user_bridge'),  # Then OVS user bridges
+            ('sriov-pf', 'sriov_pf')         # Finally SR-IOV PFs
+        ]
+        self.assertEqual(processed_devices, expected_order)
+
+    def test_process_device_removal_interface(self):
+        # Test basic interface removal
+        device = objects.RemoveNetDevice('eth0', 'interface')
+
+        def mock_ifdown(self, device_name):
+            assert device_name == 'eth0'
+
+        def mock_remove_ifcfg_config(device_name):
+            assert device_name == 'eth0'
+        self.stub_out('os_net_config.impl_ifcfg.IfcfgNetConfig.ifdown',
+                      mock_ifdown)
+        self.stub_out('os_net_config.impl_ifcfg.remove_ifcfg_config',
+                      mock_remove_ifcfg_config)
+
+        # Set noop to False for actual processing
+        self.provider.noop = False
+        self.provider._process_device_removal(device)
+
+    def test_process_device_removal_dpdk_port(self):
+        # Test DPDK port removal with cleanup
+        device = objects.RemoveNetDevice('dpdk0', 'ovs_dpdk_port')
+
+        def mock_ifdown(self, device_name):
+            assert device_name == 'dpdk0'
+
+        def mock_remove_ifcfg_config(device_name):
+            assert device_name == 'dpdk0'
+
+        self.stub_out(
+            'os_net_config.impl_ifcfg.IfcfgNetConfig.'
+            'get_dpdk_port_pci_addresses',
+            lambda self, port_name: '0000:05:00.0')
+        self.stub_out('os_net_config.utils.remove_dpdk_interface',
+                      lambda pci: None)
+        self.stub_out('os_net_config.impl_ifcfg.IfcfgNetConfig.ifdown',
+                      mock_ifdown)
+        self.stub_out('os_net_config.impl_ifcfg.remove_ifcfg_config',
+                      mock_remove_ifcfg_config)
+
+        # Set noop to False for actual processing
+        self.provider.noop = False
+        self.provider._process_device_removal(device)
+
+    def test_process_device_removal_dpdk_bond(self):
+        # Test DPDK bond removal with cleanup
+        device = objects.RemoveNetDevice('dpdkbond0', 'ovs_dpdk_bond')
+
+        def mock_ifdown(self, device_name):
+            assert device_name == 'dpdkbond0'
+
+        def mock_remove_ifcfg_config(device_name):
+            assert device_name == 'dpdkbond0'
+
+        self.stub_out(
+            'os_net_config.impl_ifcfg.IfcfgNetConfig.'
+            'get_dpdk_bond_pci_addresses',
+            lambda self, bond_name: ['0000:05:00.0', '0000:06:00.0'])
+        self.stub_out('os_net_config.utils.remove_dpdk_interface',
+                      lambda pci: None)
+        self.stub_out('os_net_config.impl_ifcfg.IfcfgNetConfig.ifdown',
+                      mock_ifdown)
+        self.stub_out('os_net_config.impl_ifcfg.remove_ifcfg_config',
+                      mock_remove_ifcfg_config)
+
+        # Set noop to False for actual processing
+        self.provider.noop = False
+        self.provider._process_device_removal(device)
+
+    def test_process_device_removal_sriov_pf(self):
+        # Test SR-IOV PF removal with cleanup
+        device = objects.RemoveNetDevice('eth0', 'sriov_pf')
+
+        def mock_ifdown(self, device_name):
+            assert device_name == 'eth0'
+
+        def mock_remove_ifcfg_config(device_name):
+            assert device_name == 'eth0'
+        self.stub_out('os_net_config.sriov_config.reset_sriov_pf',
+                      lambda dev: None)
+        self.stub_out('os_net_config.utils.remove_sriov_entries_for_pf',
+                      lambda dev: None)
+        self.stub_out('os_net_config.impl_ifcfg.IfcfgNetConfig.ifdown',
+                      mock_ifdown)
+        self.stub_out('os_net_config.impl_ifcfg.remove_ifcfg_config',
+                      mock_remove_ifcfg_config)
+
+        # Set noop to False for actual processing
+        self.provider.noop = False
+        self.provider._process_device_removal(device)
+
+    def test_process_device_removal_ovs_bridge(self):
+        # Test OVS bridge removal
+        device = objects.RemoveNetDevice('br0', 'ovs_bridge')
+
+        def mock_ifdown(self, device_name):
+            assert device_name == 'br0'
+
+        def mock_remove_ifcfg_config(device_name):
+            assert device_name == 'br0'
+
+        self.stub_out('os_net_config.impl_ifcfg.IfcfgNetConfig.ifdown',
+                      mock_ifdown)
+        self.stub_out('os_net_config.impl_ifcfg.remove_ifcfg_config',
+                      mock_remove_ifcfg_config)
+
+        # Set noop to False for actual processing
+        self.provider.noop = False
+        self.provider._process_device_removal(device)
+
+    def test_process_device_removal_ovs_user_bridge(self):
+        # Test OVS user bridge removal
+        device = objects.RemoveNetDevice('br-user', 'ovs_user_bridge')
+
+        def mock_ifdown(self, device_name):
+            assert device_name == 'br-user'
+
+        def mock_remove_ifcfg_config(device_name):
+            assert device_name == 'br-user'
+
+        self.stub_out('os_net_config.impl_ifcfg.IfcfgNetConfig.ifdown',
+                      mock_ifdown)
+        self.stub_out('os_net_config.impl_ifcfg.remove_ifcfg_config',
+                      mock_remove_ifcfg_config)
+
+        # Set noop to False for actual processing
+        self.provider.noop = False
+        self.provider._process_device_removal(device)
+
+    def test_process_device_removal_with_errors(self):
+        # Test error handling during device removal
+        device = objects.RemoveNetDevice('failing_device', 'interface')
+
+        def mock_ifdown(self, device_name):
+            raise Exception("Simulated ifdown failure")
+
+        self.stub_out('os_net_config.impl_ifcfg.IfcfgNetConfig.ifdown',
+                      mock_ifdown)
+
+        # Set noop to False for actual processing
+        self.provider.noop = False
+
+        # Should raise ConfigurationError when ifdown fails
+        self.assertRaises(os_net_config.ConfigurationError,
+                          self.provider._process_device_removal,
+                          device)
+
+    def test_remove_devices_with_backup(self):
+        # Test backup functionality when removing devices that require backup
+        devices = [
+            objects.RemoveNetDevice('dpdk0', 'ovs_dpdk_port'),
+            objects.RemoveNetDevice('eth0', 'sriov_pf')
+        ]
+
+        backup_called = False
+        backup_path_created = None
+
+        def mock_backup_map_files(backup_path):
+            nonlocal backup_called, backup_path_created
+            backup_called = True
+            backup_path_created = backup_path
+
+        def mock_makedirs(path, exist_ok=False):
+            pass
+
+        def mock_get_timestamp():
+            return "20240101_120000"
+
+        # Mock the backup functions
+        self.stub_out('os_net_config.utils.backup_map_files',
+                      mock_backup_map_files)
+        self.stub_out('os.makedirs', mock_makedirs)
+        self.stub_out('os_net_config.common.get_timestamp', mock_get_timestamp)
+
+        # Mock device processing to avoid actual operations
+        def mock_process_device_removal(self, device):
+            pass
+        self.stub_out(
+            'os_net_config.impl_ifcfg.IfcfgNetConfig._process_device_removal',
+            mock_process_device_removal)
+
+        self.provider.noop = False
+        self.provider.remove_devices(devices)
+
+        # Verify backup was called
+        self.assertTrue(backup_called)
+        self.assertIn("20240101_120000", backup_path_created)
+
+    def test_remove_devices_no_backup_needed(self):
+        # Test no backup when devices don't require it
+        devices = [
+            objects.RemoveNetDevice('eth0', 'interface'),
+            objects.RemoveNetDevice('br0', 'ovs_bridge')
+        ]
+
+        backup_called = False
+
+        def mock_backup_map_files(backup_path):
+            nonlocal backup_called
+            backup_called = True
+
+        # Mock the backup function
+        self.stub_out('os_net_config.utils.backup_map_files',
+                      mock_backup_map_files)
+
+        # Mock device processing to avoid actual operations
+        def mock_process_device_removal(self, device):
+            pass
+        self.stub_out(
+            'os_net_config.impl_ifcfg.IfcfgNetConfig._process_device_removal',
+            mock_process_device_removal)
+
+        self.provider.noop = False
+        self.provider.remove_devices(devices)
+
+        # Verify backup was NOT called
+        self.assertFalse(backup_called)
+
+    def test_remove_devices_backup_noop_mode(self):
+        # Test backup intent logged but not executed in noop mode
+        devices = [objects.RemoveNetDevice('dpdk0', 'ovs_dpdk_port')]
+
+        backup_called = False
+
+        def mock_backup_map_files(backup_path):
+            nonlocal backup_called
+            backup_called = True
+
+        # Mock the backup function
+        self.stub_out('os_net_config.utils.backup_map_files',
+                      mock_backup_map_files)
+
+        self.provider.noop = True
+        self.provider.remove_devices(devices)
+
+        # Verify backup was NOT called in noop mode
+        self.assertFalse(backup_called)


### PR DESCRIPTION
This depends on some other PRS which are open 250, 251, 271. I have integrated them and tested with those changes. But this patch need to wait for those PRs to be merged. As this has dependency on them.

This patch adds support for removing network devices through the ifcfg implementation, extending the device lifecycle management capabilities.

The implementation adds _process_device_removal() method which handles device-specific cleanup by calling utils.remove_dpdk_interface() for DPDK ports and utils.remove_sriov_entries_for_pf() for SR-IOV PFs. For DPDK devices, PCI addresses are extracted using get_dpdk_port_pci_addresses() and get_dpdk_bond_pci_addresses() functions. Interface removal uses ifdown to bring down interfaces and remove_ifcfg_config() to clean up configuration files.

Enhanced test coverage includes scenarios for successful device removal, error handling during removal failures, and comprehensive testing of all supported device types including DPDK ports, DPDK bonds, OVS bridges, and SR-IOV devices.

Test case generation Assisted-by: cursor/claude-4-sonnet