### PR TITLE
nmstate: keep_addr_on_down dispatcher script

### DIFF
--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -86,6 +86,8 @@ done
 
 ETHTOOL_SCRIPT = "{ethtool_cmd} {ethtool_opts} #ETHTOOL"
 
+SYSCTL_SCRIPT = "{sysctl_cmd} -w {sysctl_setting} #SYSCTL"
+
 _OS_NET_CONFIG_MANAGED = "# os-net-config managed table"
 
 _ROUTE_TABLE_DEFAULT = """# reserved values
@@ -1122,8 +1124,7 @@ class NmstateNetConfig(os_net_config.NetConfig):
                         )
                     self.add_dispatch_script(
                         data, POST_ACTIVATION, ethtool_script
-                        )
-
+                    )
             else:
                 command_str = '-s ${DEVICE} ' + ethtool_opts
                 command = command_str.split()
@@ -1226,6 +1227,15 @@ class NmstateNetConfig(os_net_config.NetConfig):
                     data[Interface.IPV6][InterfaceIPv6.ENABLED] = True
                     data[Interface.IPV6][InterfaceIPv6.ADDRESS].append(
                         v6ip_netmask)
+                # Set keep_addr_on_down sysctl when using static IPv6 IPs
+                _name = base_opt.name
+                sysctl_script = SYSCTL_SCRIPT.format(
+                    sysctl_cmd=utils.sysctl_path(),
+                    sysctl_setting=f"net.ipv6.conf.{_name}.keep_addr_on_down=1"
+                )
+                self.add_dispatch_script(
+                    data, POST_ACTIVATION, sysctl_script
+                )
 
         if base_opt.dhclient_args:
             msg = "DHCP Client args not supported in impl_nmstate, ignoring"

--- a/os_net_config/tests/test_impl_nmstate.py
+++ b/os_net_config/tests/test_impl_nmstate.py
@@ -55,6 +55,9 @@ _BASE_IFACE_CFG = """
     addresses:
      - ip_netmask: 2001:abc:a::2/64
      - ip_netmask: 192.168.1.2/24
+    dispatch:
+        post-activation: |
+            /sbin/sysctl -w net.ipv6.conf.em1.keep_addr_on_down=1 #SYSCTL
 """
 
 _BASE_IFACE_CFG_APPLIED = """
@@ -92,6 +95,9 @@ _BASE_IFACE_CFG_APPLIED = """
       autoconf: false
       dhcp: false
       enabled: true
+    dispatch:
+        post-activation: |
+            /sbin/sysctl -w net.ipv6.conf.eno2.keep_addr_on_down=1 #SYSCTL
 """
 
 
@@ -166,12 +172,18 @@ _V4_V6_NMCFG = _BASE_NMSTATE_IFACE_CFG + """  ipv6:
   ethernet:
     sr-iov:
       total-vfs: 0
+  dispatch:
+      post-activation: |
+          /sbin/sysctl -w net.ipv6.conf.em1.keep_addr_on_down=1 #SYSCTL
 """
 
 _V6_NMCFG = _BASE_NMSTATE_IFACE_CFG + """
   ethernet:
     sr-iov:
       total-vfs: 0
+  dispatch:
+      post-activation: |
+          /sbin/sysctl -w net.ipv6.conf.em1.keep_addr_on_down=1 #SYSCTL
   ipv4:
     enabled: False
     dhcp: False
@@ -1242,7 +1254,10 @@ class TestNmstateNetConfig(base.TestCase):
             autoconf: false
             dhcp: false
             enabled: true
-        """
+        dispatch:
+            post-activation: |
+                /sbin/sysctl -w net.ipv6.conf.%s.keep_addr_on_down=1 #SYSCTL
+        """ % 'vlan502'
         v6_addr = objects.Address('2001:abc:a::/64')
         vlan1 = objects.Vlan('em2', 502, addresses=[v6_addr])
         self.provider.add_vlan(vlan1)
@@ -1267,7 +1282,10 @@ class TestNmstateNetConfig(base.TestCase):
             autoconf: false
             dhcp: false
             enabled: true
-        """
+        dispatch:
+            post-activation: |
+                /sbin/sysctl -w net.ipv6.conf.%s.keep_addr_on_down=1 #SYSCTL
+        """ % 'em2.502'
         v6_addr = objects.Address('2001:abc:a::/64')
         em2 = objects.Interface('em2.502', addresses=[v6_addr])
         self.provider.add_interface(em2)

--- a/os_net_config/utils.py
+++ b/os_net_config/utils.py
@@ -1219,6 +1219,18 @@ def ethtool_path():
     return ethtoolcmd
 
 
+def sysctl_path():
+    """Find 'sysctl' executable."""
+    if os.access('/sbin/sysctl', os.X_OK):
+        sysctlcmd = '/sbin/sysctl'
+    elif os.access('/usr/sbin/sysctl', os.X_OK):
+        sysctlcmd = '/usr/sbin/sysctl'
+    else:
+        logger.warning("Could not execute /sbin/sysctl or /usr/sbin/sysctl")
+        return False
+    return sysctlcmd
+
+
 def set_accept_ra_sysctl(iface, noop):
     """Set /proc/sys/net/ipv6/conf/<iface>/accept_ra """
     filename = "/proc/sys/net/ipv6/conf/{}/accept_ra".format(iface)


### PR DESCRIPTION
This patch adds dispatcher script support for interfaces with static IPv6 addresses which sets the sysctl for keep_addr_on_down in order to have static IPv6 addresses act similar to static IPv4 addresses (interfaces keep their IP address when down or on reboot without requiring automatic configuration).

A follow-up patch will attempt to replicate this behavior for ifcfg files that have NM_CONTROLLED=yes, but that will require handling the dispatcher script fully within os-net-config without the benefit of native support for dispatcher script provided by nmstate.