### PR TITLE
ovs: add pci address of vf used as member of ovs_bond

### DIFF
--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -1275,6 +1275,7 @@ class OvsBond(_BaseOpts):
                                   spoofcheck=iface.spoofcheck,
                                   trust=iface.trust, state=iface.state,
                                   macaddr=iface.macaddr, promisc=iface.promisc,
+                                  pci_address=iface.pci_address,
                                   min_tx_rate=iface.min_tx_rate,
                                   max_tx_rate=iface.max_tx_rate,
                                   driver=None)

--- a/os_net_config/tests/test_objects.py
+++ b/os_net_config/tests/test_objects.py
@@ -546,13 +546,13 @@ class TestBridge(base.TestCase):
                      'vlan_id': 111, 'qos': 1,
                      'min_tx_rate': 0, 'max_tx_rate': 0,
                      'spoofcheck': 'off', 'trust': 'on',
-                     'promisc': 'on'},
+                     'promisc': 'on', 'pci_address': '0000:79:10.2'},
                     {'device_type': 'vf', 'name': 'em2_1',
                      'device': {'name': 'em2', 'vfid': 1},
                      'vlan_id': 111, 'qos': 1,
                      'min_tx_rate': 0, 'max_tx_rate': 0,
                      'spoofcheck': 'off', 'trust': 'on',
-                     'promisc': 'on'}]
+                     'promisc': 'on', 'pci_address': '0000:79:10.2'}]
 
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)
@@ -617,13 +617,15 @@ class TestBridge(base.TestCase):
                      'vlan_id': 111, 'qos': 1,
                      'min_tx_rate': 0, 'max_tx_rate': 0,
                      'spoofcheck': 'on', 'trust': 'off',
-                     'promisc': 'off'},
+                     'promisc': 'off',
+                     'pci_address': '0000:79:10.2'},
                     {'device_type': 'vf', 'name': 'em2_1',
                      'device': {'name': 'em2', 'vfid': 1},
                      'vlan_id': 111, 'qos': 1,
                      'min_tx_rate': 0, 'max_tx_rate': 0,
                      'spoofcheck': 'on', 'trust': 'off',
-                     'promisc': 'off'}]
+                     'promisc': 'off',
+                     'pci_address': '0000:79:10.2'}]
 
         def test_get_vf_devname(device, vfid):
             return device + '_' + str(vfid)


### PR DESCRIPTION
In nic partitioning case involving ovs_bond, the sriov vf map is not updated with the pci address of the VF. The pci address of the VF is now added.