### PR TITLE
dcb: remove redundant call to reset_dcb_map

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -348,7 +348,6 @@ def main(argv=sys.argv, main_logger=None):
     # If the configuration is successful, apply the DCB config
     if has_failures(onc_ret_code) is False:
         if utils.is_dcb_config_required():
-            common.reset_dcb_map()
 
             # Apply the DCB Config
             try:


### PR DESCRIPTION
Changes are done to remove the redundant call to
common.reset_dcb_map() as already this would have
got called earlier.