### PR TITLE
cli: add minimum_config & fallback_config params

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -16,6 +16,7 @@
 
 
 import argparse
+from enum import IntEnum
 import importlib
 import json
 import os
@@ -23,13 +24,24 @@ import sys
 import yaml
 
 from os_net_config import common
-from os_net_config.exit_codes import ExitCode
-from os_net_config.exit_codes import get_exit_code
-from os_net_config.exit_codes import has_failures
 from os_net_config import objects
 from os_net_config import utils
 from os_net_config import validator
 from os_net_config import version
+
+
+class ExitCode(IntEnum):
+    """Exit codes used by os-net-config.
+
+    These codes indicate the result of configuration operations:
+    - SUCCESS: Configuration completed successfully
+    - ERROR: Configuration failed due to an error
+    Below values are returned when --detailed_exit_code is enabled in cli
+    - FILES_CHANGED: Configuration successful and files were modified
+    """
+    SUCCESS = 0          # Configuration successful
+    ERROR = 1            # Configuration failed
+    FILES_CHANGED = 2    # Configuration successful, files were modified
 
 
 logger = common.configure_logger()
@@ -41,8 +53,6 @@ _PROVIDERS = {
     'iproute': 'IprouteNetConfig',
     'nmstate': 'NmstateNetConfig',
 }
-
-__all__ = ['ExitCode', 'get_exit_code', 'has_failures']
 
 
 def parse_opts(argv):
@@ -119,6 +129,25 @@ def parse_opts(argv):
         action='store_true',
         help="Install the configuration but don't start/stop interfaces.",
         required=False)
+
+    parser.add_argument('--minimum-config', action='store_true',
+                        help="""Apply minimum_config section before """
+                             """applying network_config. This is useful to apply """
+                             """temporary networking during migrating between """
+                             """providers, or to initialize networking before """
+                             """applying network_config. This option is not """
+                             """idempotent and should not be used repeatedly.""",
+                        dest='minimum_config',
+                        default=False)
+
+    parser.add_argument('--fallback-config', action='store_true',
+                        help="""Apply fallback_config section if errors occur"""
+                             """applying network_config. This is useful to apply """
+                             """temporary networking for remote access to debug """
+                             """or troubleshoot. This option can remove existing """
+                             """configuration if errors occur making changes.""",
+                        dest='fallback_config',
+                        default=False)
 
     parser.add_argument(
         '--cleanup',
@@ -202,8 +231,6 @@ def is_nmstate_available():
 
 
 def main(argv=sys.argv, main_logger=None):
-    onc_ret_code = ExitCode.SUCCESS
-
     opts = parse_opts(argv)
 
     common.set_noop(opts.noop)
@@ -235,6 +262,7 @@ def main(argv=sys.argv, main_logger=None):
     if opts.interfaces is not None:
         reported_nics = {}
         mapped_nics = objects.mapped_nics(iface_mapping)
+        retval = ExitCode.SUCCESS
         if len(opts.interfaces) > 0:
             for requested_nic in opts.interfaces:
                 found = False
@@ -253,7 +281,7 @@ def main(argv=sys.argv, main_logger=None):
                         reported_nics[requested_nic] = requested_nic
                         found = True
                 if not found:
-                    onc_ret_code |= ExitCode.ERROR
+                    retval = ExitCode.ERROR
             if reported_nics:
                 main_logger.debug(
                     "Interface mapping requested for interface: %s",
@@ -266,7 +294,7 @@ def main(argv=sys.argv, main_logger=None):
         # cleanly, otherwise exit with status ERROR.
         main_logger.debug("Interface report requested, exiting after report.")
         print(json.dumps(reported_nics))
-        return onc_ret_code
+        return retval
     try:
         iface_array = get_iface_config(
             "network_config",
@@ -276,15 +304,11 @@ def main(argv=sys.argv, main_logger=None):
             strict_validate=opts.exit_on_validation_errors,
         )
     except objects.InvalidConfigException as e:
-        main_logger.error(
-            "Schema validation failed for network_config with error: \n%s", e
-        )
-        return get_exit_code(opts.detailed_exit_codes,
-                             onc_ret_code | ExitCode.SCHEMA_VALIDATION_FAILED)
+        main_logger.error("Schema validation failed for network_config\n%s", e)
+        return ExitCode.ERROR
 
     if not iface_array:
-        return get_exit_code(opts.detailed_exit_codes,
-                             onc_ret_code | ExitCode.ERROR)
+        return ExitCode.ERROR
 
     # Reset the DCB Config during rerun.
     # This is required to apply the new values and clear the old ones
@@ -298,16 +322,11 @@ def main(argv=sys.argv, main_logger=None):
             opts.root_dir,
             opts.noop
         )
-        onc_ret_code |= purge_ret
-        if purge_ret == ExitCode.PURGE_FAILED:
+        if purge_ret != ExitCode.SUCCESS:
             main_logger.error(
-                "%s: Failed to purge provider", opts.purge_provider
+                "Failed to purge %s provider", opts.purge_provider
             )
-            return get_exit_code(opts.detailed_exit_codes, onc_ret_code)
-        else:
-            main_logger.info(
-                "%s: Purged provider successfully", opts.purge_provider
-            )
+            return purge_ret
 
     if not opts.provider:
         ifcfg_path = f'{opts.root_dir}/etc/sysconfig/network-scripts/'
@@ -320,48 +339,43 @@ def main(argv=sys.argv, main_logger=None):
         else:
             main_logger.error("Unable to set provider for this operating "
                               "system.")
-            return get_exit_code(opts.detailed_exit_codes,
-                                 onc_ret_code | ExitCode.ERROR)
-    logger.info("%s: Applying network_config section", opts.provider)
-    ret_code = config_provider(
-        opts.provider,
-        "network_config",
-        iface_array,
-        opts.root_dir,
-        opts.noop,
-        opts.no_activate,
-        opts.cleanup,
-    )
-    if ret_code == ExitCode.ERROR:
-        logger.error(
-            "%s: Failed to configure network_config. ",
+            return ExitCode.ERROR
+
+    try:
+        logger.info("%s: Applying network_config section", opts.provider)
+        ret_code = config_provider(
             opts.provider,
+            "network_config",
+            iface_array,
+            opts.root_dir,
+            opts.noop,
+            opts.no_activate,
+            opts.cleanup,
         )
-        return get_exit_code(opts.detailed_exit_codes,
-                             onc_ret_code | ExitCode.NETWORK_CONFIG_FAILED)
+    except Exception as e:
+        logger.error(
+            "%s: *** Failed to apply network_config section ***\n%s",
+            opts.provider,
+            e
+        )
+        ret_code = ExitCode.ERROR
+
+    if utils.is_dcb_config_required():
+        # Apply the DCB Config
+        try:
+            from os_net_config import dcb_config
+        except ImportError as e:
+            logger.error("cannot apply DCB configuration: %s", e)
+            return ExitCode.ERROR
+
+        utils.configure_dcb_config_service()
+        dcb_apply = dcb_config.DcbApplyConfig()
+        dcb_apply.apply()
+
+    if opts.detailed_exit_codes or ret_code == ExitCode.ERROR:
+        return ret_code
     else:
-        onc_ret_code |= ret_code
-        main_logger.info(
-            "%s: Configured network_config successfully", opts.provider
-        )
-
-    # If the configuration is successful, apply the DCB config
-    if has_failures(onc_ret_code) is False:
-        if utils.is_dcb_config_required():
-            common.reset_dcb_map()
-
-            # Apply the DCB Config
-            try:
-                from os_net_config import dcb_config
-            except ImportError as e:
-                logger.error("cannot apply DCB configuration: %s", e)
-                return (onc_ret_code | ExitCode.DCB_CONFIG_FAILED)
-
-            utils.configure_dcb_config_service()
-            dcb_apply = dcb_config.DcbApplyConfig()
-            dcb_apply.apply()
-
-    return get_exit_code(opts.detailed_exit_codes, onc_ret_code)
+        return ExitCode.SUCCESS
 
 
 def unconfig_provider(provider_name,
@@ -385,7 +399,7 @@ def unconfig_provider(provider_name,
         logger.error(
             "%s: cannot load purge provider, error %s", provider_name, e
         )
-        return ExitCode.PURGE_FAILED
+        return ExitCode.ERROR
 
     for iface_json in iface_array:
         try:


### PR DESCRIPTION
Add support for minimum_config and fallback_config to cli.py. The minimum_config option configures basic networking prior to applying the network_config. The fallback_config applies after network_config if errors occur during configuration.

Signed-off-by: Dan Sneddon <dsneddon@redhat.com>