### PR TITLE
ifcfg: set sysctl to set keep_addr_on_down

### DIFF
--- a/os_net_config/common.py
+++ b/os_net_config/common.py
@@ -72,6 +72,12 @@ SRIOV_CONFIG_FILE = '/var/lib/os-net-config/sriov_config.yaml'
 
 DCB_CONFIG_FILE = '/var/lib/os-net-config/dcb_config.yaml'
 
+# Directory to write sysctl settings to
+# Format of the file shall be
+# net.ipv6.conf.default.keep_addr_on_down=1
+# net.ipv6.conf.all.keep_addr_on_down=1
+SYSCTLD_CONF_DIR = '/usr/lib/sysctl.d'
+
 _SYS_BUS_PCI_DEV = '/sys/bus/pci/devices'
 SYS_CLASS_NET = '/sys/class/net'
 _LOG_FILE = '/var/log/os-net-config.log'
@@ -190,6 +196,22 @@ def write_yaml_config(filepath, data):
     os.makedirs(os.path.dirname(filepath), exist_ok=True)
     with open(filepath, 'w') as f:
         yaml.safe_dump(data, f, default_flow_style=False)
+
+
+def write_sysctld_conf(filename, sysctls=[]):
+    filepath = SYSCTLD_CONF_DIR + '/' + filename
+    filedata = '# Written by os-net-config, do not modify\n'
+    filedata += '\n'.join(sysctls) + '\n'
+    logger.info("Writing file %s with content %s", filepath, filedata)
+    if get_noop():
+        return
+    try:
+        with open(filepath, 'w') as f:
+            f.write(str(filedata))
+            return True
+    except IOError:
+        logger.error("Error writing file: %s", filename)
+        raise
 
 
 def update_dcb_map(device, pci_addr, driver, noop, dscp2prio=None):

--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -750,6 +750,11 @@ class IfcfgNetConfig(os_net_config.NetConfig):
             data += "MTU=%i\n" % base_opt.mtu
         if base_opt.use_dhcpv6 or base_opt.v6_addresses():
             data += "IPV6INIT=yes\n"
+            keep_addr_sysctls = ["net.ipv6.conf.default.keep_addr_on_down=1",
+                                 "net.ipv6.conf.all.keep_addr_on_down=1"]
+            common.write_sysctld_conf("90-v6_keep_addr.conf",
+                                      keep_addr_sysctls)
+            utils.set_keep_addr_sysctl(base_opt.name, self.noop)
             if base_opt.mtu:
                 data += "IPV6_MTU=%i\n" % base_opt.mtu
         if base_opt.use_dhcpv6:

--- a/os_net_config/utils.py
+++ b/os_net_config/utils.py
@@ -942,3 +942,18 @@ def set_accept_ra_sysctl(iface, noop):
         if os.path.exists(filename):
             with open(filename, 'w') as f:
                 f.write("0")
+
+
+def set_keep_addr_sysctl(iface, noop):
+    """Set /proc/sys/net/ipv6/conf/<iface>/keep_addr_on_down """
+    filename = "/proc/sys/net/ipv6/conf/{}/keep_addr_on_down".format(iface)
+    logger.info(
+        "%s: Setting sysctl net.ipv6.conf.%s.keep_addr_on_down=1",
+        iface,
+        iface
+    )
+    if not noop:
+        # Set sysctl
+        if os.path.exists(filename):
+            with open(filename, 'w') as f:
+                f.write("1")


### PR DESCRIPTION
Write a sysctl.d config file in /usr/lib/sysctl.d when
IPv6 addresses are used to set keep_addr_on_down as a
default and for all existing interfaces. This behavior
is default for IPv4 addresses and needs to be used for
IPv6 addresses on systems that are routing IPv6.

Signed-off-by: Dan Sneddon <dsneddon@redhat.com>