### PR TITLE
nmstate: fix sysctl path for tests

### DIFF
--- a/os_net_config/tests/test_impl_nmstate.py
+++ b/os_net_config/tests/test_impl_nmstate.py
@@ -236,6 +236,11 @@ class TestNmstateNetConfig(base.TestCase):
         common.DPDK_MAPPING_FILE = '/tmp/dpdk_mapping.yaml'
         common.SRIOV_CONFIG_FILE = '/tmp/sriov_config.yaml'
 
+        def sysctl_path_stub():
+            return "/sbin/sysctl"
+        self.stub_out('os_net_config.utils.sysctl_path',
+                      sysctl_path_stub)
+
         self.stub_out("os_net_config.common.interface_mac",
                       generate_random_mac)
         impl_nmstate.DISPATCHER_SCRIPT_PREFIX = ""

--- a/os_net_config/utils.py
+++ b/os_net_config/utils.py
@@ -1269,13 +1269,16 @@ def ethtool_path():
 
 def sysctl_path():
     """Find 'sysctl' executable."""
+    if common.get_noop():
+        return "/sbin/sysctl"
+
     if os.access('/sbin/sysctl', os.X_OK):
         sysctlcmd = '/sbin/sysctl'
     elif os.access('/usr/sbin/sysctl', os.X_OK):
         sysctlcmd = '/usr/sbin/sysctl'
     else:
         logger.warning("Could not execute /sbin/sysctl or /usr/sbin/sysctl")
-        return False
+        return ""
     return sysctlcmd
 
 


### PR DESCRIPTION
The sysctl_path() needs to be stubbed for the unit tests to pass.