### PR TITLE
ifcfg: fix mixed provider compatibility with nmstate

### DIFF
--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -2959,6 +2959,8 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
             for device in devices_of_type:
                 self._process_device_removal(device)
+
+        self.execute("Reloading network", "nmcli", "connection", "reload")
         return ExitCode.SUCCESS
 
     def phy_dev_up(self, interface):

--- a/os_net_config/tests/test_impl_ifcfg.py
+++ b/os_net_config/tests/test_impl_ifcfg.py
@@ -3562,6 +3562,11 @@ class TestIfcfgNetConfigDeviceRemoval(base.TestCase):
             'os_net_config.impl_ifcfg.IfcfgNetConfig._process_device_removal',
             mock_process_device_removal)
 
+        # Mock execute method to avoid nmcli command execution
+        def mock_execute(*args, **kwargs):
+            return
+        self.stub_out('os_net_config.NetConfig.execute', mock_execute)
+
         self.provider.noop = False
         self.provider.remove_devices(devices)
 
@@ -3592,6 +3597,11 @@ class TestIfcfgNetConfigDeviceRemoval(base.TestCase):
         self.stub_out(
             'os_net_config.impl_ifcfg.IfcfgNetConfig._process_device_removal',
             mock_process_device_removal)
+
+        # Mock execute method to avoid nmcli command execution
+        def mock_execute(*args, **kwargs):
+            return
+        self.stub_out('os_net_config.NetConfig.execute', mock_execute)
 
         self.provider.noop = False
         self.provider.remove_devices(devices)


### PR DESCRIPTION
When using cloud-init generated ifcfg connections with nmstate provider, NetworkManager connection conflicts occurred due to stale connection cache. Adding nmcli connection reload after device removal ensures NetworkManager recognizes the updated network state, allowing mixed scenarios (cloud-init ifcfg + nmstate configuration) to work correctly.