### PR TITLE
rm_config: Fix incorrect nic mapping for RemoveNetDevice

### DIFF
--- a/os_net_config/cli.py
+++ b/os_net_config/cli.py
@@ -234,9 +234,10 @@ def main(argv=sys.argv, main_logger=None):
 
     # If --interfaces is specified, either return the real name of the
     # interfaces specified, or return the map of all nic abstractions/names.
+    # update the nic mapping initially, so that it is consistent throughout
+    mapped_nics = objects.mapped_nics(iface_mapping)
     if opts.interfaces is not None:
         reported_nics = {}
-        mapped_nics = objects.mapped_nics(iface_mapping)
         if len(opts.interfaces) > 0:
             for requested_nic in opts.interfaces:
                 found = False

--- a/os_net_config/objects.py
+++ b/os_net_config/objects.py
@@ -2264,4 +2264,5 @@ class RemoveNetDevice(object):
                                           'remove_name', 'RemoveNetDevice')
         remove_type = _get_required_field(json,
                                           'remove_type', 'RemoveNetDevice')
-        return RemoveNetDevice(remove_name, remove_type)
+        nic_mapping = json.get('nic_mapping')
+        return RemoveNetDevice(remove_name, remove_type, nic_mapping)


### PR DESCRIPTION
The nic_mapping was not being provided during the instantiation of RemoveNetDevice in the from_json() method. This resulted in incorrect nic mapping being written to the remove configuration, causing devices to not be properly identified by their mapped names during removal operations.

The fix ensures that nic_mapping is extracted from the JSON and passed to the RemoveNetDevice constructor, allowing proper NIC name resolution during device removal.