### PR TITLE
cli: add minimum_config and fallback_config params

### DIFF
--- a/os_net_config/tests/test_cli.py
+++ b/os_net_config/tests/test_cli.py
@@ -986,7 +986,7 @@ class TestCli(base.TestCase):
             root_dir="",
             noop=False
         )
-        self.assertEqual(ret, ExitCode.SUCCESS)
+        self.assertEqual(ret, ExitCode.FALLBACK_FAILED)
 
     def test_safe_fallback_empty_config(self):
         """Test safe_fallback with empty fallback_config."""
@@ -997,7 +997,7 @@ class TestCli(base.TestCase):
             root_dir="",
             noop=False
         )
-        self.assertEqual(ret, ExitCode.SUCCESS)
+        self.assertEqual(ret, ExitCode.FALLBACK_FAILED)
 
     def test_safe_fallback_long_config(self):
         """Test safe_fallback with empty fallback_config."""


### PR DESCRIPTION
    cli: add minimum_config and fallback_config params
    
    Add support for minimum_config and fallback_config to cli.py.
    The minimum_config option configures basic networking prior to
    applying the network_config. The fallback_config applies after
    network_config if errors occur during configuration.
    
    Signed-off-by: Dan Sneddon <dsneddon@redhat.com>
    Co-authored-by: Karthik Sundaravel <ksundara@redhat.com>
