### PR TITLE
tests: fix ignored exceptions in unit tests

### DIFF
--- a/os_net_config/tests/test_impl_ifcfg.py
+++ b/os_net_config/tests/test_impl_ifcfg.py
@@ -2605,9 +2605,13 @@ class TestIfcfgNetConfigApply(base.TestCase):
 
     def tearDown(self):
         self.temp_ifcfg_file.close()
+        self.temp_bond_file.close()
         self.temp_route_file.close()
         self.temp_route6_file.close()
+        self.temp_route_table_file.close()
+        self.temp_rule_file.close()
         self.temp_bridge_file.close()
+        self.temp_sysctl_file.close()
         if os.path.exists(self.temp_cleanup_file.name):
             self.temp_cleanup_file.close()
         super(TestIfcfgNetConfigApply, self).tearDown()

--- a/os_net_config/tests/test_impl_nmstate.py
+++ b/os_net_config/tests/test_impl_nmstate.py
@@ -309,6 +309,8 @@ class TestNmstateNetConfig(base.TestCase):
                       test_bind_dpdk_interfaces)
 
     def tearDown(self):
+        # Close temporary files before cleanup
+        self.temp_route_table_file.close()
         super(TestNmstateNetConfig, self).tearDown()
         if os.path.isfile(common.SRIOV_CONFIG_FILE):
             os.remove(common.SRIOV_CONFIG_FILE)


### PR DESCRIPTION
    tests: fix ignored exceptions in unit tests
    
    There were few exceptions thrown during the execution of unit tests like
    
    Exception ignored in: <function _TemporaryFileCloser.__del__ at ...>
    
    These exceptions were avoided now.
    
    Signed-off-by: Karthik Sundaravel <ksundara@redhat.com>