### PR TITLE
revert: ifcfg: report failure in bringing up ovs bridges

### DIFF
--- a/os_net_config/__init__.py
+++ b/os_net_config/__init__.py
@@ -490,34 +490,14 @@ class NetConfig(object):
 
         Print a message and run a command with processutils
         in noop mode, this just prints a message.
-
-        :param parse_errors: If True, raises ProcessExecutionError when 'error'
-                            is found in stdout or stderr. Default: False.
         """
-        parse_errors = kwargs.pop('parse_errors', False)
         logger.info("%s%s", self.log_prefix, msg)
         if not self.noop:
             out, err = processutils.execute(cmd, *args, **kwargs)
             if err:
                 logger.error("stderr : %s", err)
-                # Check if error is mentioned in stderr
-                if parse_errors and 'error' in err.lower():
-                    raise processutils.ProcessExecutionError(
-                        exit_code=None,
-                        stdout=out,
-                        stderr=err,
-                        cmd=' '.join([str(cmd)] + [str(a) for a in args])
-                    )
             if out:
                 logger.debug("stdout : %s", out)
-                # Check if error is mentioned in stdout
-                if parse_errors and 'error' in out.lower():
-                    raise processutils.ProcessExecutionError(
-                        exit_code=None,
-                        stdout=out,
-                        stderr=err,
-                        cmd=' '.join([str(cmd)] + [str(a) for a in args])
-                    )
 
     def write_config(self, filename, data, msg=None):
         msg = msg or "Writing config %s" % filename
@@ -546,15 +526,12 @@ class NetConfig(object):
         to self.errors for later handling.  This allows callers to continue
         trying to bring up interfaces even if one fails.
 
-        This method enables error parsing to detect and fail on 'error'
-        messages in stdout/stderr from the ifup command.
-
         :param interface: The name of the interface to be started.
         :param iftype: The type of the interface.
         """
         msg = 'running ifup on %s: %s' % (iftype, interface)
         try:
-            self.execute(msg, '/sbin/ifup', interface, parse_errors=True)
+            self.execute(msg, '/sbin/ifup', interface)
         except processutils.ProcessExecutionError as e:
             self.errors.append(e)
 

--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -2513,9 +2513,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                 message = 'Failure(s) occurred when applying configuration'
                 logger.error(message)
                 for e in self.errors:
-                    logger.error(
-                        '\nstdout: %s \nstderr: %s', e.stdout, e.stderr
-                    )
+                    logger.error('stdout: %s, stderr: %s', e.stdout, e.stderr)
                 raise os_net_config.ConfigurationError(message)
 
         return update_files
@@ -2731,7 +2729,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
     def _check_dpdk_files_for_pci_address(self, net_device, dev_name,
                                           dev_pci_address):
-        """Check ifcfg files for DPDK ports/bonds matching device's PCI.
+        """Check ifcfg files for DPDK ports/bonds matching device's PCI address.
 
         :param net_device: RemoveNetDevice object for the SR-IOV VF/ interface
         :param dev_name: Name of the VF/ interface to match


### PR DESCRIPTION
Reverts os-net-config/os-net-config#312
This commit is creating regression for non-ovs interfaces, hence reverting 