### PR TITLE
execute: fix stderr logging level for successful commands

### DIFF
--- a/os_net_config/__init__.py
+++ b/os_net_config/__init__.py
@@ -495,7 +495,7 @@ class NetConfig(object):
         if not self.noop:
             out, err = processutils.execute(cmd, *args, **kwargs)
             if err:
-                logger.error("stderr : %s", err)
+                logger.warning("stderr : %s", err)
             if out:
                 logger.debug("stdout : %s", out)
 


### PR DESCRIPTION
i) Commit 8a74a133e41d2909e42fecf004488b601e0ed141 had to be reverted as it was creating a regression	for non	ovs interfaces.

ii) But in order to revert i) we had to revert another commit d13b650717a718bcf0e6f0b3d3f3b45cbc70a547 which was already on top of i)

After reverting both commits successfully, need to commit back ii)

stderr output from successful commands (exit code 0) is now properly categorized as WARNING.

We have logs as below currently
ERROR os_net_config.execute stderr : WARN: [ifup] You are using 'ifup'
ERROR os_net_config.execute stderr : usage: ifdown <configuration>

With this commit they will be printed as below
WARNING os_net_config.execute stderr : WARN: [ifup] You are using 'ifup'
WARNING os_net_config.execute stderr : usage: ifdown <configuration>