### PR TITLE
docs: remove all references to opendev/openstack

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -1,4 +1,0 @@
-[gerrit]
-host=review.opendev.org
-port=29418
-project=openstack/os-net-config.git

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -1,4 +1,0 @@
-os-net-config Style Commandments
-================================
-
-Read the OpenStack Style Commandments https://docs.openstack.org/hacking/latest/

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,9 @@ Overview
 backend configuration providers. One of: ifcfg (network-init-scripts), 
 nmstate (NetworkManager), or eni (basic support for /etc/network/interfaces)
 
+* Issues: https://github.com/os-net-config/os-net-config/issues
+* Documentation: https://github.com/os-net-config/os-net-config/tree/master/doc
+
 Features
 --------
 
@@ -44,11 +47,49 @@ __ https://github.com/os-net-config/os-net-config/blob/master/CONTRIBUTING.rst
 Installation
 ------------
 
-* RPM based
-  os-net-config is part of Openstack RHEL8+, you may install it using 'sudo yum install os-net-config'
+* **RPM based**
+  os-net-config is available for RHEL8+ and similar distributions.
 
-* From source code
-  Use git to download source and then 'cd os-net-confg', 'python setup.py install --prefix=/usr'
+  .. code-block:: bash
+
+     sudo dnf install os-net-config
+     # or
+     sudo yum install os-net-config
+
+* **From source**
+  Use git to download source and then:
+
+  .. code-block:: bash
+
+     git clone https://github.com/os-net-config/os-net-config.git
+     cd os-net-config
+     python setup.py install --prefix=/usr
+     # or using pip
+     pip install .
+
+* **From PyPI**
+
+  .. code-block:: bash
+
+     pip install os-net-config
+
+Community
+---------
+
+os-net-config is now maintained as an independent community project. While it was
+originally developed under OpenStack governance, the project continues to evolve
+as a standalone tool for declarative network configuration.
+
+**Project Resources:**
+
+* GitHub Organization: https://github.com/os-net-config
+* Main Repository: https://github.com/os-net-config/os-net-config
+
+**Community Participation:**
+
+We welcome contributions from the community! Whether you're fixing bugs,
+adding features, improving documentation, or helping other users, your
+participation is valued and appreciated.
 
 License
 -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,19 @@
 [metadata]
 name = os-net-config
-summary = OpenStack network configuration
+summary = Declarative network configuration tool for hosts
 description_file =
     README.rst
-author = OpenStack
-author_email = openstack-discuss@lists.openstack.org
+author = os-net-config Community
+author_email = os-net-config@noreply.github.com
+maintainer = os-net-config Community
 license = Apache License (2.0)
 home_page = https://github.com/os-net-config/os-net-config
+project_urls =
+    Release Notes = https://github.com/os-net-config/os-net-config/releases
+    Source Code = https://github.com/os-net-config/os-net-config
 classifier =
-    Environment :: OpenStack
+    Environment :: Console
+    Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     Intended Audience :: System Administrators
     License :: OSI Approved :: Apache Software License
@@ -19,6 +24,8 @@ classifier =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Topic :: System :: Networking
+    Topic :: System :: Systems Administration
 
 [files]
 packages =


### PR DESCRIPTION
- Update setup and README files to update about the repo not being part of opendev anymore