### PR TITLE
nmstate: delete vlan devices with name <iface>.<vlanid>

### DIFF
--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -1567,6 +1567,9 @@ class NmstateNetConfig(os_net_config.NetConfig):
         iface_data = {Interface.NAME: interface.name,
                       Interface.TYPE: InterfaceType.ETHERNET,
                       Interface.STATE: InterfaceState.ABSENT}
+        if re.match(r'\w+\.\d+$', interface.name):
+            iface_data[Interface.TYPE] = InterfaceType.VLAN
+
         self.del_device["iface"].append(iface_data)
 
     def add_interface(self, interface):


### PR DESCRIPTION
The vlan device could be provided in the form <interface>.<vlan-id>.
This format of representation needs to be handled during the destroy of
vlans.