### PR TITLE
ifcfg: vlans could not be removed during purge provider

### DIFF
--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -69,24 +69,23 @@ def ifcfg_config_path(name):
 
 
 def remove_ifcfg_config(ifname):
-    if re.match(r'[\w-]+$', ifname):
-        ifcfg_file = ifcfg_config_path(ifname)
-        route_file = route_config_path(ifname)
-        route6_file = route6_config_path(ifname)
-        rule_file = route_rule_config_path(ifname)
+    ifcfg_file = ifcfg_config_path(ifname)
+    route_file = route_config_path(ifname)
+    route6_file = route6_config_path(ifname)
+    rule_file = route_rule_config_path(ifname)
 
-        src_files = [
-            ifcfg_file,
-            route_file,
-            route6_file,
-            rule_file
-        ]
-        for src in src_files:
-            try:
-                logger.info("%s: removing file %s", ifname, src)
-                os.remove(src)
-            except FileNotFoundError:
-                logger.debug("%s: not found", src)
+    src_files = [
+        ifcfg_file,
+        route_file,
+        route6_file,
+        rule_file
+    ]
+    for src in src_files:
+        try:
+            logger.info("%s: removing file %s", ifname, src)
+            os.remove(src)
+        except FileNotFoundError:
+            logger.debug("%s: not found", src)
 
 
 # NOTE(dprince): added here for testability
@@ -962,8 +961,12 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param interface: The Interface object to be deleted.
         """
-        logger.info("%s: Deleting", interface)
-        self._del_common(interface)
+        if re.match(r'\w+\.\d+$', interface.name):
+            logger.info("%s: Deleting vlan ", interface.name)
+            self.del_device["vlan"].append(interface.name)
+        else:
+            logger.info("%s: Deleting", interface.name)
+            self._del_common(interface)
 
     def add_vlan(self, vlan):
         """Add a Vlan object to the net config object.
@@ -984,7 +987,7 @@ class IfcfgNetConfig(os_net_config.NetConfig):
 
         :param vlan: The vlan object to be deleted.
         """
-        logger.info("%s: Deleting vlan ", vlan)
+        logger.info("%s: Deleting vlan ", vlan.name)
         self.del_device["vlan"].append(vlan.name)
 
     def add_ivs_interface(self, ivs_interface):


### PR DESCRIPTION
The ifcfg file for vlans with name format <device>.<vlan-id> are avoided from being removed due to the dot in the name. The sane is handled now.