### PR TITLE
schema: remove un-supported configs in brigde, bond interfaces

### DIFF
--- a/os_net_config/schema.yaml
+++ b/os_net_config/schema.yaml
@@ -672,7 +672,6 @@ definitions:
                     oneOf:
                       - $ref: "#/definitions/interface"
                       - $ref: "#/definitions/vlan"
-                      - $ref: "#/definitions/ovs_bond"
                       - $ref: "#/definitions/ovs_patch_port"
                       - $ref: "#/definitions/ovs_tunnel"
                       - $ref: "#/definitions/ovs_dpdk_bond"
@@ -733,7 +732,6 @@ definitions:
                     oneOf:
                       - $ref: "#/definitions/interface"
                       - $ref: "#/definitions/sriov_vf"
-                      - $ref: "#/definitions/vlan"
                       - $ref: "#/definitions/sriov_pf"
                 minItems: 1
             ovs_options:
@@ -1301,7 +1299,6 @@ definitions:
                 items:
                     oneOf:
                       - $ref: "#/definitions/interface"
-                      - $ref: "#/definitions/vlan"
                       - $ref: "#/definitions/sriov_vf"
                       - $ref: "#/definitions/sriov_pf"
             bonding_options:

--- a/os_net_config/tests/test_validator.py
+++ b/os_net_config/tests/test_validator.py
@@ -334,6 +334,19 @@ class TestDeviceTypes(base.TestCase):
         }
         self.assertTrue(v.is_valid(data))
 
+    def test_ovs_bond_with_vlan_member(self):
+        schema = validator.get_schema_for_defined_type("ovs_bond")
+        v = jsonschema.Draft4Validator(schema)
+        data = {
+            "type": "ovs_bond",
+            "name": "bond2",
+            "members": [
+                {"type": "interface", "name": "em2"},
+                {"type": "vlan", "device": "em1", "vlan_id": 200}
+            ]
+        }
+        self.assertFalse(v.is_valid(data))
+
     def test_ovs_user_bridge(self):
         schema = validator.get_schema_for_defined_type("ovs_user_bridge")
         v = jsonschema.Draft4Validator(schema)
@@ -363,6 +376,26 @@ class TestDeviceTypes(base.TestCase):
             }]
         }
         self.assertTrue(v.is_valid(data))
+
+    def test_usrbridge_with_ovsbond_member(self):
+        schema = validator.get_schema_for_defined_type("ovs_user_bridge")
+        v = jsonschema.Draft4Validator(schema)
+        data = {
+            "type": "ovs_user_bridge",
+            "name": "br-data0",
+            "members": [{
+                "type": "ovs_dpdk_port", "name": "dpdk1",
+                    "members": [{
+                        "type": "interface", "name": "em1"
+                    }]
+                }, {
+                "type": "ovs_bond", "name": "br-2",
+                    "members": [{
+                        "type": "interface", "name": "em2"
+                    }]
+            }]
+        }
+        self.assertFalse(v.is_valid(data))
 
     def test_ovs_patch_port(self):
         schema = validator.get_schema_for_defined_type("ovs_patch_port")
@@ -427,6 +460,20 @@ class TestDeviceTypes(base.TestCase):
             ]
         }
         self.assertTrue(v.is_valid(data))
+
+    def test_linux_bond_with_vlan_member(self):
+        schema = validator.get_schema_for_defined_type("linux_bond")
+        v = jsonschema.Draft4Validator(schema)
+        data = {
+            "type": "linux_bond",
+            "name": "bond1",
+            "bonding_options": "mode=active-backup",
+            "members": [
+                {"type": "interface", "name": "em1"},
+                {"type": "vlan", "vlan_id": 200, "device": "em2"}
+            ]
+        }
+        self.assertFalse(v.is_valid(data))
 
     def test_nfvswitch_bridge(self):
         schema = validator.get_schema_for_defined_type("nfvswitch_bridge")


### PR DESCRIPTION
- ovs_bond cannot contain vlan members
- linux_bond cannot contain vlan members
- ovs_user_bridge cannot contain ovs_bond members

Added negative test cases to verify schema enforcement of allowed member types for network bonding and bridge devices

Fixes: https://issues.redhat.com/browse/OSPRH-25687