### PR TITLE
ifcfg: update accept_ra when no static+dynamic addr is specified

### DIFF
--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -887,6 +887,21 @@ class IfcfgNetConfig(os_net_config.NetConfig):
                     if ":" in route.next_hop:
                         data += f"IPV6_DEFAULTGW={route.next_hop}\n"
                         data += f"IPV6_DEFAULTDEV={base_opt.name}\n"
+        # If no static addr is configured and IPv6 is globally enabled with
+        # accept_ra disabled, explicitly disable RA to avoid unintended
+        # IPv6 auto-configuration.
+        # Also make sure accept_ra is not set for the "dynamic IPv4 only"
+        # (for backward compatibility with existing ifcfg-* behavior)
+        elif not base_opt.use_dhcp:
+            ipv6_disabled = utils.get_sysctl_value(
+                'net.ipv6.conf.default.disable_ipv6')
+            accept_ra_default = utils.get_sysctl_value(
+                'net.ipv6.conf.default.accept_ra')
+
+            if (ipv6_disabled == '0' and accept_ra_default == '0'):
+                data += "IPV6_AUTOCONF=no\n"
+                data += "IPV6_SET_SYSCTLS=yes\n"
+                data += "IPV6_FORCE_ACCEPT_RA=no\n"
 
         if base_opt.hwaddr:
             data += "HWADDR=%s\n" % base_opt.hwaddr

--- a/os_net_config/tests/test_impl_ifcfg.py
+++ b/os_net_config/tests/test_impl_ifcfg.py
@@ -232,6 +232,12 @@ IPV6_FORCE_ACCEPT_RA=no
 IPV6ADDR=2001:abc:a::/64
 """
 
+_NO_IP_IPV6_RA_DISABLED = _BASE_IFCFG + """BOOTPROTO=none
+IPV6_AUTOCONF=no
+IPV6_SET_SYSCTLS=yes
+IPV6_FORCE_ACCEPT_RA=no
+"""
+
 _V6_IFCFG_MULTIPLE = (_V6_IFCFG + "IPV6ADDR_SECONDARIES=\"2001:abc:b::1/64 " +
                       "2001:abc:c::2/96\"\n")
 
@@ -810,6 +816,20 @@ class TestIfcfgNetConfig(base.TestCase):
             return "0000:00:02.0"
         if 'em1' in ifname:
             return "0000:00:01.0"
+
+    def make_sysctl_stub(self, overrides=None):
+        defaults = {
+            'net.ipv6.conf.default.disable_ipv6': '0',
+            'net.ipv6.conf.default.accept_ra': '0',
+        }
+
+        if overrides:
+            defaults.update(overrides)
+
+        def stub_get_sysctl_value(sysctl_path):
+            return defaults.get(sysctl_path)
+
+        return stub_get_sysctl_value
 
     def test_add_route_table(self):
         route_table1 = objects.RouteTable('table1', 200)
@@ -2611,6 +2631,69 @@ OVS_EXTRA="set Interface dpdk0 options:dpdk-devargs=0000:00:08.0 \
         finally:
             if os.path.exists(tmp.name):
                 os.remove(tmp.name)
+
+    def test_interface_no_ip_with_ipv6_disabled(self):
+        """Test interface with no addrs when IPv6 is disabled globally"""
+        self.stub_out(
+            'os_net_config.utils.get_sysctl_value',
+            self.make_sysctl_stub({
+                'net.ipv6.conf.default.disable_ipv6': '1'
+            })
+        )
+
+        # Create interface with no addresses
+        interface = objects.Interface('em1')
+        self.provider.add_interface(interface)
+
+        # Should NOT include IPV6_AUTOCONF=no settings
+        self.assertEqual(_NO_IP, self.get_interface_config())
+
+    def test_interface_no_ip_with_global_accept_ra_disabled(self):
+        """Test intf with no addr when global accept_ra is disabled"""
+        # Mock sysctl values: IPv6 enabled (0), accept_ra disabled (0)
+        self.stub_out(
+            'os_net_config.utils.get_sysctl_value',
+            self.make_sysctl_stub({
+                'net.ipv6.conf.default.accept_ra': '0'
+            })
+        )
+
+        # Create interface with no addresses
+        interface = objects.Interface('em1')
+        self.provider.add_interface(interface)
+
+        # Should include IPV6_AUTOCONF=no settings
+        self.assertEqual(_NO_IP_IPV6_RA_DISABLED, self.get_interface_config())
+
+    def test_interface_no_ip_with_global_accept_ra_enabled(self):
+        """Test intf with no addrs when global accept_ra is enabled"""
+        self.stub_out(
+            'os_net_config.utils.get_sysctl_value',
+            self.make_sysctl_stub({
+                'net.ipv6.conf.default.accept_ra': '1'
+            })
+        )
+        # Create interface with no addresses
+        interface = objects.Interface('em1')
+        self.provider.add_interface(interface)
+
+        # Should NOT include IPV6_AUTOCONF=no settings
+        self.assertEqual(_NO_IP, self.get_interface_config())
+
+    def test_interface_with_addresses_ignores_accept_ra_check(self):
+        """Test that intf with static addr doesn't trigger accept_ra check"""
+        # Mock sysctl values: IPv6 enabled, accept_ra disabled
+        self.stub_out(
+            'os_net_config.utils.get_sysctl_value',
+            self.make_sysctl_stub()
+        )
+        # Create interface with IPv4 address
+        v4_addr = objects.Address('192.168.1.2/24')
+        interface = objects.Interface('em1', addresses=[v4_addr])
+        self.provider.add_interface(interface)
+
+        # Should use standard V4 config (not trigger no-address path)
+        self.assertEqual(_V4_IFCFG, self.get_interface_config())
 
 
 class TestIfcfgNetConfigApply(base.TestCase):

--- a/os_net_config/utils.py
+++ b/os_net_config/utils.py
@@ -1376,3 +1376,35 @@ def write_bonding_masters(bond_name, action="add"):
     else:
         logger.info("NOOP: Would write '%s' to %s",
                     write_value, bonding_masters_path)
+
+
+def get_sysctl_value(sysctl_path):
+    """Read a sysctl value from /proc/sys filesystem
+
+    :param sysctl_path: Sysctl param path
+                        (e.g. 'net.ipv6.conf.all.disable_ipv6')
+    :returns: The sysctl value as a string, or None if not found
+    """
+    filename = "/proc/sys/{}".format(sysctl_path.replace('.', '/'))
+    try:
+        if os.path.exists(filename):
+            with open(filename, 'r') as f:
+                return f.read().strip()
+    except (IOError, OSError) as e:
+        logger.debug("Failed to read sysctl %s: %s", sysctl_path, e)
+    return None
+
+
+def set_keep_addr_sysctl(iface, noop):
+    """Set /proc/sys/net/ipv6/conf/<iface>/keep_addr_on_down """
+    filename = "/proc/sys/net/ipv6/conf/{}/keep_addr_on_down".format(iface)
+    logger.info(
+        "%s: Setting sysctl net.ipv6.conf.%s.keep_addr_on_down=1",
+        iface,
+        iface
+    )
+    if not noop:
+        # Set sysctl
+        if os.path.exists(filename):
+            with open(filename, 'w') as f:
+                f.write("1")


### PR DESCRIPTION
This change adds proper IPv6 RA handling for interfaces without addresses set, preventing unintended IPv6 autoconfiguration based on global sysctl settings.

- If IPv6 is enabled globally AND RA is disabled by default, update ifcfg- to disable auto-conf
- Added new methods to read sysctl
- Updated tests cases for few possible scenarios

Closes: https://issues.redhat.com/browse/OSPRH-26347

(cherry picked from commit 54027dd3ad0f2f67d5aac3f087a53d4bd803504a)