### PR TITLE
ifcfg: add ovs_extra support for Linux bonds

### DIFF
--- a/os_net_config/schema.yaml
+++ b/os_net_config/schema.yaml
@@ -649,7 +649,6 @@ definitions:
                     oneOf:
                       - $ref: "#/definitions/interface"
                       - $ref: "#/definitions/vlan"
-                      - $ref: "#/definitions/ovs_bond"
                       - $ref: "#/definitions/ovs_patch_port"
                       - $ref: "#/definitions/ovs_tunnel"
                       - $ref: "#/definitions/ovs_dpdk_bond"
@@ -710,7 +709,6 @@ definitions:
                     oneOf:
                       - $ref: "#/definitions/interface"
                       - $ref: "#/definitions/sriov_vf"
-                      - $ref: "#/definitions/vlan"
                       - $ref: "#/definitions/sriov_pf"
                 minItems: 1
             ovs_options:
@@ -1278,7 +1276,6 @@ definitions:
                 items:
                     oneOf:
                       - $ref: "#/definitions/interface"
-                      - $ref: "#/definitions/vlan"
                       - $ref: "#/definitions/sriov_vf"
                       - $ref: "#/definitions/sriov_pf"
             bonding_options:

--- a/os_net_config/tests/test_validator.py
+++ b/os_net_config/tests/test_validator.py
@@ -335,6 +335,19 @@ class TestDeviceTypes(base.TestCase):
         }
         self.assertTrue(v.is_valid(data))
 
+    def test_ovs_bond_with_vlan_member(self):
+        schema = validator.get_schema_for_defined_type("ovs_bond")
+        v = jsonschema.Draft4Validator(schema)
+        data = {
+            "type": "ovs_bond",
+            "name": "bond2",
+            "members": [
+                {"type": "interface", "name": "em2"},
+                {"type": "vlan", "device": "em1", "vlan_id": 200}
+            ]
+        }
+        self.assertFalse(v.is_valid(data))
+
     def test_ovs_user_bridge(self):
         schema = validator.get_schema_for_defined_type("ovs_user_bridge")
         v = jsonschema.Draft4Validator(schema)
@@ -364,6 +377,26 @@ class TestDeviceTypes(base.TestCase):
             }]
         }
         self.assertTrue(v.is_valid(data))
+
+    def test_usrbridge_with_ovsbond_member(self):
+        schema = validator.get_schema_for_defined_type("ovs_user_bridge")
+        v = jsonschema.Draft4Validator(schema)
+        data = {
+            "type": "ovs_user_bridge",
+            "name": "br-data0",
+            "members": [{
+                "type": "ovs_dpdk_port", "name": "dpdk1",
+                    "members": [{
+                        "type": "interface", "name": "em1"
+                    }]
+                }, {
+                "type": "ovs_bond", "name": "br-2",
+                    "members": [{
+                        "type": "interface", "name": "em2"
+                    }]
+            }]
+        }
+        self.assertFalse(v.is_valid(data))
 
     def test_ovs_patch_port(self):
         schema = validator.get_schema_for_defined_type("ovs_patch_port")


### PR DESCRIPTION
This commit adds support for ovs_extra configuration in Linux bonds, allowing users to specify additional OVS commands for bonded interfaces when used as OVS bridge members.

Changes:
- Add ovs_extra parameter to LinuxBond constructor and from_json method
- Process ovs_extra templates using format_ovs_extra function
- Validate that ovs_extra is only allowed for OVS bridge members
- Extend bridge's ovs_extra list with bond's ovs_extra commands
- Update schema to include ovs_extra property for linux_bond type

This enables configuration like:
  ovs_extra: ["set port $DEVICE other_config:stp-path-cost=2"]