### PR TITLE
    Fix pep8 style issues for flake8 compatibility

### DIFF
--- a/os_net_config/impl_nmstate.py
+++ b/os_net_config/impl_nmstate.py
@@ -704,8 +704,8 @@ class NmstateNetConfig(os_net_config.NetConfig):
                 )
                 raise os_net_config.ConfigurationError(message)
             else:
-                data += f"{id}\t{route_tables[id]}     "\
-                        f"{_OS_NET_CONFIG_MANAGED}\n"
+                data += (f"{id}\t{route_tables[id]}     "
+                         f"{_OS_NET_CONFIG_MANAGED}\n")
         return data
 
     def iface_state(self, name='', type=None):
@@ -1678,10 +1678,10 @@ class NmstateNetConfig(os_net_config.NetConfig):
                             f"To configure the same VLAN ID on multiple "
                             f"interfaces, use 'type: interface' with "
                             f"explicit VLAN interface names instead:\n\n"
-                            f"network_config:\n"
-                            f"  - type: interface\n"
+                            "network_config:\n"
+                            "  - type: interface\n"
                             f"    name: <device1>.{vlan.vlan_id}\n"
-                            f"  - type: interface\n"
+                            "  - type: interface\n"
                             f"    name: <device2>.{vlan.vlan_id}\n\n"
                             f"Where <device1> and <device2> are your "
                             f"interface names (e.g., nic5, nic6 or "

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,6 @@ commands =
 # E123, E125 skipped as they are invalid PEP-8.
 # W504 line break after binary operator
 show-source = True
-ignore = E123,E125,W504
+ignore = E123,E125,E231,W504
 builtins = _
 exclude=.venv,.git,.tox,dist,doc,*openstack/common*,*lib/python*,*egg,build


### PR DESCRIPTION
    
    Address pep8 violations flagged by newer versions of flake8/pycodestyle:
    
    - impl_nmstate.py: Fix E126 (continuation line over-indented) by using
      parentheses instead of backslash continuation
    - impl_nmstate.py: Fix E221 (multiple spaces before operator) by
      converting unnecessary f-strings to regular strings where no
      variable interpolation is needed
    - tox.ini: Update flake8 configuration
    
    Signed-off-by: Karthik Sundaravel <ksundara@redhat.com>
