### PR TITLE
Revert "ifcfg: remove sysctl flag from script"

### DIFF
--- a/os_net_config/impl_ifcfg.py
+++ b/os_net_config/impl_ifcfg.py
@@ -789,17 +789,13 @@ class IfcfgNetConfig(os_net_config.NetConfig):
         # IPv6 auto-configuration.
         # Also make sure accept_ra is not set for the "dynamic IPv4 only"
         # (for backward compatibility with existing ifcfg-* behavior)
-        # accept_ra will be handled by kernel in router mode
         elif not base_opt.use_dhcp:
             ipv6_disabled = utils.get_sysctl_value(
                 'net.ipv6.conf.default.disable_ipv6')
             accept_ra_default = utils.get_sysctl_value(
                 'net.ipv6.conf.default.accept_ra')
-            ipv6_forwarding = utils.get_sysctl_value(
-                'net.ipv6.conf.default.forwarding')
 
-            if (ipv6_disabled == '0' and accept_ra_default == '0' and
-                    ipv6_forwarding == '0'):
+            if (ipv6_disabled == '0' and accept_ra_default == '0'):
                 data += "IPV6_AUTOCONF=no\n"
                 data += "IPV6_SET_SYSCTLS=yes\n"
                 data += "IPV6_FORCE_ACCEPT_RA=no\n"

--- a/os_net_config/tests/test_impl_ifcfg.py
+++ b/os_net_config/tests/test_impl_ifcfg.py
@@ -785,7 +785,6 @@ class TestIfcfgNetConfig(base.TestCase):
         defaults = {
             'net.ipv6.conf.default.disable_ipv6': '0',
             'net.ipv6.conf.default.accept_ra': '0',
-            'net.ipv6.conf.default.forwarding': '1'
         }
 
         if overrides:
@@ -2420,8 +2419,7 @@ OVS_EXTRA="set Interface dpdk0 options:dpdk-devargs=0000:00:08.0 \
         self.stub_out(
             'os_net_config.utils.get_sysctl_value',
             self.make_sysctl_stub({
-                'net.ipv6.conf.default.accept_ra': '0',
-                'net.ipv6.conf.default.forwarding': '0'
+                'net.ipv6.conf.default.accept_ra': '0'
             })
         )
 


### PR DESCRIPTION
Reverts os-net-config/os-net-config#343, after discussing the impact of FRR use case here:
If FRR environment file is included, the environment file sets net.ipv6.conf.all.forwarding=1 in it. 
The scenario is below.
1. First run of os-net-config at node provision phase, underlying devices for bonding devices will have IPV6_SET_SYSCTLS, IPV6_AUTOCONF and IPV6_FORCE_ACCEPT_RA.
2. At overcloud deploy command, net.ipv6.conf.all.forwarding=1 is set by including FRR environment files.
3. After overcloud deploy, if the customer wants to update the network configuration with os-net-config, os-net-config will not include IPV6_SET_SYSCTLS, IPV6_AUTOCONF and IPV6_FORCE_ACCEPT_RA to bonding underlying devices.
4. 3. will restart an interface even if the device doesn't have any changes because the rendered netconfig file has difference. Then restarting interface will have an impact on kernel parameters